### PR TITLE
Make bower install non-interactive which was hanging automated install via Arch package

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
 	},
 
 	"scripts": {
-		"postinstall": "bower install",
+		"postinstall": "bower --config.interactive=false install",
 		"build": "grunt release",
 		"test": "grunt test"
 	}


### PR DESCRIPTION
I'm trying to make an Arch package for livestreamer-twitch-gui, and if it installs bower as a dependency, the first time it's run, it asks whether you want to enable analytics, stalling the install. The fix for this is to tell bower not to be interactive.