### PR TITLE
Custom chat methods

### DIFF
--- a/build/resources/windows/msie-minimal.vbs
+++ b/build/resources/windows/msie-minimal.vbs
@@ -1,0 +1,5 @@
+Dim objIENoToolbars
+Set objIENoToolbars = WScript.CreateObject("InternetExplorer.Application")
+ObjIENoToolbars.Toolbar = false
+objIENoToolbars.Navigate WScript.Arguments.Item(0)
+objIENoToolbars.Visible = true

--- a/build/tasks/configs/compile.js
+++ b/build/tasks/configs/compile.js
@@ -1,9 +1,11 @@
 module.exports = {
 	win32: {
-		before: [ "clean:release_win32" ]
+		before: [ "clean:release_win32" ],
+		after : [ "copy:win32scripts" ]
 	},
 	win64: {
-		before: [ "clean:release_win64" ]
+		before: [ "clean:release_win64" ],
+		after : [ "copy:win64scripts" ]
 	},
 
 	osx32: {

--- a/build/tasks/configs/copy.js
+++ b/build/tasks/configs/copy.js
@@ -24,6 +24,19 @@ module.exports = {
 		}
 	},
 
+	win32scripts: {
+		expand : true,
+		flatten: true,
+		src    : "build/resources/windows/*",
+		dest   : "build/releases/<%= package.name %>/win32/"
+	},
+	win64scripts: {
+		expand : true,
+		flatten: true,
+		src    : "build/resources/windows/*",
+		dest   : "build/releases/<%= package.name %>/win64/"
+	},
+
 	linux32scripts: {
 		options: { mode: 493 }, // 0755 (js strict mode)
 		expand : true,

--- a/package.json
+++ b/package.json
@@ -141,25 +141,6 @@
 					]
 				}
 			},
-			"firefox": {
-				"args": "-chrome '{url}'",
-				"exec": {
-					"win32": [ "firefox.exe" ],
-					"darwin": [ "firefox" ],
-					"linux": [ "firefox" ]
-				},
-				"fallback": {
-					"win32": [
-						"%PROGRAMFILES%\\Mozilla Firefox",
-						"%PROGRAMFILES(X86)%\\Mozilla Firefox"
-					],
-					"darwin": [ "/Applications/Firefox.app/Contents/MacOS" ],
-					"linux": [
-						"/usr/bin",
-						"/usr/local/bin"
-					]
-				}
-			},
 			"msie": {
 				"args": "\"{script}\" \"{url}\"",
 				"exec": "cscript",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,75 @@
 		"notification-cache-time": 7,
 		"notification-retries": 3,
 		"notification-interval": 60000,
-		"stream-reload-interval": 60000
+		"stream-reload-interval": 60000,
+		"chat-methods": {
+			"chromium": {
+				"args": "--app={url}",
+				"exec": {
+					"win32": [ "chrome.exe" ],
+					"darwin": [ "Chromium" ],
+					"linux": [ "chromium-browser" ]
+				},
+				"fallback": {
+					"win32": [
+						"%LOCALAPPDATA%\\Chromium\\Application",
+						"%PROGRAMFILES%\\Chromium\\Application",
+						"%PROGRAMFILES(X86)%\\Chromium\\Application"
+					],
+					"darwin": [ "/Applications/Chromium.app/Contents/MacOS" ],
+					"linux": [
+						"/usr/bin",
+						"/usr/local/bin",
+						"/opt/chromium"
+					]
+				}
+			},
+			"chrome": {
+				"args": "--app={url}",
+				"exec": {
+					"win32": [ "chrome.exe" ],
+					"darwin": [ "Google Chrome" ],
+					"linux": [ "google-chrome", "google-chrome-unstable" ]
+				},
+				"fallback": {
+					"win32": [
+						"%LOCALAPPDATA%\\Google\\Chrome\\Application",
+						"%PROGRAMFILES%\\Google\\Chrome\\Application",
+						"%PROGRAMFILES(X86)%\\Google\\Chrome\\Application"
+					],
+					"darwin": [ "/Applications/Google Chrome.app/Contents/MacOS" ],
+					"linux": [
+						"/usr/bin",
+						"/usr/local/bin",
+						"/opt/google/chrome"
+					]
+				}
+			},
+			"firefox": {
+				"args": "-chrome '{url}'",
+				"exec": {
+					"win32": [ "firefox.exe" ],
+					"darwin": [ "firefox" ],
+					"linux": [ "firefox" ]
+				},
+				"fallback": {
+					"win32": [
+						"%PROGRAMFILES%\\Mozilla Firefox",
+						"%PROGRAMFILES(X86)%\\Mozilla Firefox"
+					],
+					"darwin": [ "/Applications/Firefox.app/Contents/MacOS" ],
+					"linux": [
+						"/usr/bin",
+						"/usr/local/bin"
+					]
+				}
+			},
+			"msie": {
+				"args": "\"{script}\" \"{url}\"",
+				"exec": "cscript",
+				"script": "msie-minimal.vbs"
+			}
+		}
 	},
 
 	"scripts": {

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -119,6 +119,7 @@ define(function( require ) {
 		SettingsService: require( "services/SettingsService" ),
 		AuthService: require( "services/AuthService" ),
 		NotificationService: require( "services/NotificationService" ),
+		ChatService: require( "services/ChatService" ),
 
 
 		// Application

--- a/src/app/controllers/SettingsController.js
+++ b/src/app/controllers/SettingsController.js
@@ -26,6 +26,17 @@ define([
 		hlsSegmentThreadsMin    : settingsAttrMeta( "hls_segment_threads", "minValue" ),
 		hlsSegmentThreadsMax    : settingsAttrMeta( "hls_segment_threads", "maxValue" ),
 
+		chatMethods: function() {
+			var methods = get( this, "settings.content.constructor.chat_methods" );
+			return methods.filter(function( method ) {
+				return !method.disabled;
+			});
+		}.property( "settings.content" ),
+
+		isChatMethodDefault: equal( "model.chat_method", "default" ),
+		isChatMethodMSIE   : equal( "model.chat_method", "msie" ),
+		isChatMethodCustom : equal( "model.chat_method", "custom" ),
+
 		hasTaskBarIntegration: equal( "model.gui_integration", 1 ),
 		hasBothIntegrations  : equal( "model.gui_integration", 3 ),
 

--- a/src/app/mixins/ChannelMixin.js
+++ b/src/app/mixins/ChannelMixin.js
@@ -6,6 +6,7 @@ define( [ "Ember", "nwjs/nwGui" ], function( Ember, nwGui ) {
 	return Ember.Mixin.create({
 		metadata: Ember.inject.service(),
 		auth    : Ember.inject.service(),
+		chat    : Ember.inject.service(),
 
 		checkUserFollowsChannel: function( channel ) {
 			if ( !get( this, "auth.session.isLoggedIn" ) ) { return; }
@@ -96,14 +97,9 @@ define( [ "Ember", "nwjs/nwGui" ], function( Ember, nwGui ) {
 			},
 
 			"chat": function( channel, callback ) {
-				var url  = get( this, "metadata.config.twitch-chat-url" );
-				var name = get( channel, "id" );
-				if ( url && name ) {
-					this.send( "openBrowser", url.replace( "{channel}", name ) );
-					if ( callback instanceof Function ) {
-						callback();
-					}
-				}
+				var chat = get( this, "chat" );
+				chat.open( channel )
+					.then( callback );
 			},
 
 			"share": function( channel, callback ) {

--- a/src/app/models/localstorage/Settings.js
+++ b/src/app/models/localstorage/Settings.js
@@ -3,6 +3,7 @@ define( [ "Ember", "EmberData" ], function( Ember, DS ) {
 	var get = Ember.get;
 	var set = Ember.set;
 	var attr = DS.attr;
+	var isWin = process.platform === "win32";
 
 	function defaultLangFilterValue( model ) {
 		var codes = get( model, "metadata.config.language_codes" );
@@ -41,6 +42,8 @@ define( [ "Ember", "EmberData" ], function( Ember, DS ) {
 		notify_badgelabel   : attr( "boolean", { defaultValue: true } ),
 		hls_live_edge       : attr( "number",  { defaultValue: 3, minValue: 1, maxValue: 10 } ),
 		hls_segment_threads : attr( "number",  { defaultValue: 1, minValue: 1, maxValue: 10 } ),
+		chat_method         : attr( "string",  { defaultValue: "default" } ),
+		chat_command        : attr( "string",  { defaultValue: "" } ),
 
 
 		// correct old value
@@ -104,6 +107,18 @@ define( [ "Ember", "EmberData" ], function( Ember, DS ) {
 			{ id: 1, label: "Go to favorites" },
 			{ id: 2, label: "Open all streams" },
 			{ id: 3, label: "Open all streams+chats" }
+		],
+
+		chat_methods: [
+			// TODO: change to "browser"
+			{ id: "default",  label: "Default Browser" },
+			// TODO: change to "default"
+			{ id: "irc",      label: "Internal IRC Client", disabled: true },
+			{ id: "chromium", label: "Chromium" },
+			{ id: "chrome",   label: "Google Chrome" },
+			{ id: "firefox",  label: "Mozilla Firefox" },
+			{ id: "msie",     label: "Internet Explorer", disabled: !isWin },
+			{ id: "custom",   label: "Custom application" }
 		]
 
 	});

--- a/src/app/models/localstorage/Settings.js
+++ b/src/app/models/localstorage/Settings.js
@@ -116,7 +116,6 @@ define( [ "Ember", "EmberData" ], function( Ember, DS ) {
 			{ id: "irc",      label: "Internal IRC Client", disabled: true },
 			{ id: "chromium", label: "Chromium" },
 			{ id: "chrome",   label: "Google Chrome" },
-			{ id: "firefox",  label: "Mozilla Firefox" },
 			{ id: "msie",     label: "Internet Explorer", disabled: !isWin },
 			{ id: "custom",   label: "Custom application" }
 		]

--- a/src/app/services/ChatService.js
+++ b/src/app/services/ChatService.js
@@ -1,0 +1,220 @@
+define([
+	"Ember",
+	"nwjs/nwGui",
+	"utils/Parameter",
+	"utils/ParameterCustom",
+	"utils/Substitution",
+	"utils/resolvePath",
+	"utils/fs/which",
+	"utils/fs/stat"
+], function(
+	Ember,
+	nwGui,
+	Parameter,
+	ParameterCustom,
+	Substitution,
+	resolvePath,
+	which,
+	stat
+) {
+
+	var CP   = require( "child_process" );
+	var PATH = require( "path" );
+
+	var get = Ember.get;
+	var readOnly = Ember.computed.readOnly;
+	var run = Ember.run;
+
+	var platform = process.platform;
+	var isWin = platform === "win32";
+
+	function checkExec( stat ) {
+		return stat.isFile() && ( isWin || ( stat.mode & 73 ) > 0 );
+	}
+
+	function launch( exec, params ) {
+		return new Promise(function( resolve, reject ) {
+			var spawn = CP.spawn( exec, params, { detached: true } );
+			spawn.on( "error", reject );
+			run.next( resolve );
+		});
+	}
+
+
+	return Ember.Service.extend({
+		metadata: Ember.inject.service(),
+		settings: Ember.inject.service(),
+
+		chatMethods: readOnly( "metadata.config.chat-methods" ),
+
+		/**
+		 * @param channel
+		 * @returns {Promise}
+		 */
+		open: function( channel ) {
+			var url  = get( this, "metadata.config.twitch-chat-url" );
+			var name = get( channel, "id" );
+
+			if ( !url || !name ) {
+				return Promise.reject( new Error( "Missing URL or channel name" ) );
+			}
+
+			url = url.replace( "{channel}", name );
+
+			var advanced = get( this, "settings.advanced" );
+			var method   = get( this, "settings.chat_method" );
+			var command  = get( this, "settings.chat_command" ).trim();
+
+			if ( !advanced ) {
+				method = "default";
+			}
+
+			switch ( method ) {
+				case "default":
+				case "browser":
+					return this._openDefaultBrowser( url );
+				case "irc":
+					return this._openIRC( channel );
+				case "chromium":
+				case "chrome":
+				case "firefox":
+					return this._openPredefined( command, method, url );
+				case "msie":
+					return this._openMSIE( url );
+				case "custom":
+					return this._openCustom( command, name, url );
+				default:
+					return Promise.reject( new Error( "Invalid chat method" ) );
+			}
+		},
+
+
+		_openDefaultBrowser: function( url ) {
+			return new Promise(function( resolve ) {
+				nwGui.Shell.openExternal( url );
+				run.next( resolve );
+			});
+		},
+
+
+		_openIRC: function() {
+			return Promise.reject( new Error( "Not yet implemented" ) );
+		},
+
+
+		_openPredefined: function( command, key, url ) {
+			var methods  = get( this, "chatMethods" );
+			var data     = methods[ key ];
+			var args     = data[ "args" ];
+			var exec     = data[ "exec" ][ platform ];
+			var fallback = data[ "fallback" ][ platform ];
+
+			// validate command and use fallback paths if needed
+			return this._validatePredefined( command, exec, fallback )
+				.then(function( exec ) {
+					var params = Parameter.getParameters(
+						{ args: args, url : url },
+						[ new ParameterCustom( null, "args", true ) ],
+						[ new Substitution( "url", "url" ) ]
+					);
+
+					return launch( exec, params );
+				});
+		},
+
+		_validatePredefined: function( command, executables, fallbacks ) {
+			// user has set a custom executable path
+			if ( command.length ) {
+				// validate command:
+				// check if the command's executable name is equal to one of the given ones
+				var exec = PATH.basename( command );
+				return executables.indexOf( exec ) !== -1
+					? which( command, checkExec )
+					: Promise.reject( new Error( "Invalid command" ) );
+
+			} else {
+				// look for matching executables inside the $PATH variable first
+				return executables.reduce(function( chain, exec ) {
+					return chain.catch(function() {
+						// check file
+						return which( exec, checkExec );
+					});
+				}, Promise.reject() )
+					.catch( function() {
+						// or look for matching executables in a list of fallback paths
+						return fallbacks.reduce(function( chain, fallback ) {
+							return chain.catch(function() {
+								// resolve env variables
+								fallback = resolvePath( fallback );
+								// append each executable to the current path
+								return executables.reduce(function( chain, exec ) {
+									return chain.catch(function() {
+										var file = PATH.join( fallback, exec );
+										// check file (absolute path)
+										return which( file, checkExec );
+									});
+								}, Promise.reject() );
+							});
+						}, Promise.reject() );
+					});
+			}
+		},
+
+
+		_openMSIE: function( url ) {
+			var data   = get( this, "chatMethods.msie" );
+			var args   = data[ "args" ];
+			var exec   = data[ "exec" ];
+			var script = data[ "script" ];
+
+			// the script needs to be inside the application's folder
+			var dir    = PATH.dirname( process.execPath );
+			var file   = PATH.join( dir, script );
+
+			return stat( file )
+				.then(function() {
+					var params = Parameter.getParameters(
+						{
+							args  : args,
+							script: file,
+							url   : url
+						},
+						[
+							new ParameterCustom( null, "args", true )
+						],
+						[
+							new Substitution( "url", "url" ),
+							new Substitution( "script", "script" )
+						]
+					);
+
+					return launch( exec, params );
+				});
+		},
+
+
+		_openCustom: function( command, channel, url ) {
+			var params = Parameter.getParameters(
+				{
+					command: command,
+					channel: channel,
+					url    : url
+				},
+				[
+					new ParameterCustom( null, "command", true )
+				],
+				[
+					new Substitution( "url", "url" ),
+					new Substitution( "channel", "channel" )
+				]
+			);
+			var exec = params.shift();
+
+			return which( exec, checkExec )
+				.then(function() {
+					return launch( exec, params );
+				});
+		}
+	});
+
+});

--- a/src/app/utils/ParameterCustom.js
+++ b/src/app/utils/ParameterCustom.js
@@ -12,10 +12,11 @@ define( [ "utils/Parameter" ], function( Parameter ) {
 	 * @extends Parameter
 	 * @param {(string|string[]|Function)?} cond
 	 * @param {string?} value
+	 * @param {boolean?} subst
 	 * @constructor
 	 */
-	function ParameterCustom( cond, value ) {
-		Parameter.call( this, undefined, cond, value );
+	function ParameterCustom( cond, value, subst ) {
+		Parameter.call( this, undefined, cond, value, subst );
 	}
 
 	ParameterCustom.prototype = Object.create( Parameter.prototype );
@@ -24,10 +25,11 @@ define( [ "utils/Parameter" ], function( Parameter ) {
 
 	/**
 	 * @param {Object} obj
+	 * @param {Substitution[]} substitutions
 	 * @returns {string[]}
 	 */
-	ParameterCustom.prototype.get = function( obj ) {
-		var value = this.getValue( obj );
+	ParameterCustom.prototype.get = function( obj, substitutions ) {
+		var value = this.getValue( obj, substitutions );
 		return value === false
 			? []
 			: this.tokenize( value );

--- a/src/app/utils/resolvePath.js
+++ b/src/app/utils/resolvePath.js
@@ -1,0 +1,26 @@
+define( [ "Ember" ], function() {
+
+	var PATH = require( "path" );
+
+	var reVarWindows = /%([^%]+)%/g;
+	var reVarUnix    = /\$([A-Z_]+)/g;
+
+	function fnVarReplace( _, v ) {
+		return process.env[ v ];
+	}
+
+	function resolvePathWindows( path ) {
+		path = path.replace( reVarWindows, fnVarReplace );
+		return PATH.resolve( path );
+	}
+
+	function resolvePathUnix( path ) {
+		path = path.replace( reVarUnix, fnVarReplace );
+		return PATH.resolve( path );
+	}
+
+	return process.platform === "win32"
+		? resolvePathWindows
+		: resolvePathUnix;
+
+});

--- a/src/styles/content/settings.less
+++ b/src/styles/content/settings.less
@@ -89,7 +89,8 @@
 		.radiobtns-color( @color-neutral, @button-color );
 	}
 
-	.selecter.notifications {
+	.selecter.notifications,
+	.selecter.chat-method {
 		max-width: 14em;
 	}
 

--- a/src/templates/settings.html.hbs
+++ b/src/templates/settings.html.hbs
@@ -8,10 +8,27 @@
 <legend>Streams</legend>
 <div><i class="fa fa-eye"></i> Preferred quality<span>Choose the default stream quality.</span></div>
 <div>{{view "select" value=model.quality content=settings.content.constructor.qualities optionValuePath="content.id" optionLabelPath="content.label"}}</div>
-<div><i class="fa fa-comment"></i> Open chat<span>After launching a stream.</span></div>
-<div>{{#check-box checked=model.gui_openchat}}Automatically open chat{{/check-box}}</div>
 <div><i class="fa fa-info-circle"></i> Stream popup<span>When a stream has started.</span></div>
 <div>{{#check-box checked=model.gui_hidestreampopup}}Hide the popup on success{{/check-box}}</div>
+</fieldset>
+<fieldset>
+<legend>Chat</legend>
+{{#if model.advanced}}
+<div><i class="fa fa-twitch"></i> Chat method<span>Explicitly choose a browser to be able to use minimal chat windows.</span></div>
+<div>{{view "select" class="chat-method" value=model.chat_method content=chatMethods optionValuePath="content.id" optionLabelPath="content.label"}}</div>
+{{#unless (bool-or isChatMethodDefault isChatMethodMSIE)}}
+<div><i class="fa fa-cog"></i> Executable location<span>
+{{#if isChatMethodCustom}}
+Available parameters: <span title="Name of the channel">{channel}</span> and <span title="Twitch chat URL">{url}</span>.<br>Example: <span class="docs">/path/to/app --name {channel} {url}</span>
+{{else}}
+Choose a custom executable file of your selected browser. If left blank, default installation paths are assumed.
+{{/if}}
+</span></div>
+<div>{{file-select value=model.chat_command inputClass="form-control" placeholder=(if isChatMethodCustom "Application path and parameters" "Custom browser executable")}}</div>
+{{/unless}}
+{{/if}}
+<div><i class="fa fa-comment"></i> Open chat<span>After launching a stream.</span></div>
+<div>{{#check-box checked=model.gui_openchat}}Automatically open chat{{/check-box}}</div>
 </fieldset>
 <fieldset>
 <legend>Livestreamer</legend>


### PR DESCRIPTION
This enables chat windows without address and bookmarks bars and also adds support for custom chat applications.

Previously, the chat was being opened by calling [`require( "nw.gui" ).Shell.openExternal( url )`](https://github.com/nwjs/nw.js/wiki/Shell#openexternaluri), so it was impossible https://github.com/bastimeyer/livestreamer-twitch-gui/issues/60#issuecomment-80911797 to hide the address and bookmarks bar of the browser window. To be able to do this, the browser executable had to be known, so special launch parameters could be set, but by using `openExternal` there was no way of doing it.

As I've already said here https://github.com/bastimeyer/livestreamer-twitch-gui/issues/9#issuecomment-134084214, I wanted to keep it as simple as possible. The most reasonable solution for me was adding a list of supported web browsers with predefined parameters, so those don't have to be inserted by the average user. Support for a custom command line has also been added, so different applications can be used, too.

I'm opening this pull request instead of just merging these changes, because I'd like to have some feedback first.

Right now, there's an issue with the Firefox implementation. The used parameters (`firefox -chrome http://www.twitch.tv/CHANNEL/chat`) should be correct, but the twitch chat refuses to load and I don't know why this is happening. I'm not a Firefox user, so if someone knows what's going on, please let me know, thanks.

The dropdown is hidden behind the advanced settings, but I'm not sure if this is really needed.

Build instructions can be found [here](https://github.com/bastimeyer/livestreamer-twitch-gui/blob/v0.9.3/CONTRIBUTING.md#developing-and-building)