### PR TITLE
Added support for OS X-style refresh

### DIFF
--- a/src/app/components/ApplicationComponent.js
+++ b/src/app/components/ApplicationComponent.js
@@ -52,7 +52,8 @@ define([
 			document.documentElement.addEventListener( "keyup", function( e ) {
 				var f5    = e.keyCode === 116;
 				var ctrlR = e.keyCode ===  82 && e.ctrlKey === true;
-				if ( f5 || ctrlR ) {
+				var metaR = e.keyCode ===  82 && e.metaKey === true;
+				if ( f5 || ctrlR || metaR ) {
 					controller.send( "refresh" );
 				}
 			}, false );


### PR DESCRIPTION
Since OS X per default uses meta instead of ctrl I added this feature to the refresh eventlistener. 