### PR TITLE
Predefined player parameters

### DIFF
--- a/src/app/config.js
+++ b/src/app/config.js
@@ -6,6 +6,7 @@ import update from "root/config/update.json";
 import themes from "root/config/themes.json";
 import langs from "root/config/langs.json";
 import livestreamer from "root/config/livestreamer.json";
+import players from "root/config/players.json";
 import twitch from "root/config/twitch.json";
 import notification from "root/config/notification.json";
 import chat from "root/config/chat.json";
@@ -20,6 +21,7 @@ export {
 	themes,
 	langs,
 	livestreamer,
+	players,
 	twitch,
 	notification,
 	chat

--- a/src/app/controllers/SettingsController.js
+++ b/src/app/controllers/SettingsController.js
@@ -83,11 +83,14 @@ export default Controller.extend( RetryTransitionMixin, {
 		return presetList;
 	}),
 
-	playerPresetFields: computed( "model.player_preset", function() {
-		let preset = get( this, "model.player_preset" );
-		if ( !preset || !players.hasOwnProperty( preset ) ) { return []; }
-
-		return players[ preset ][ "params" ];
+	playerPresetFields: computed(function() {
+		return kPlayers.reduce(function( list, preset ) {
+			list.push( ...players[ preset ].params.map(function( param ) {
+				param.preset = preset;
+				return param;
+			}) );
+			return list;
+		}, [] );
 	}),
 
 

--- a/src/app/controllers/SettingsController.js
+++ b/src/app/controllers/SettingsController.js
@@ -7,6 +7,7 @@ import {
 	Controller
 } from "Ember";
 import {
+	players,
 	langs,
 	themes
 } from "config";
@@ -14,12 +15,16 @@ import RetryTransitionMixin from "mixins/RetryTransitionMixin";
 import { playerSubstitutions } from "models/LivestreamerParameters";
 import qualities from "models/LivestreamerQualities";
 import Settings from "models/localstorage/Settings";
-import platform from "utils/node/platform";
+import platform, {
+	platform as platformName
+} from "utils/node/platform";
 
 
 const { alias, equal } = computed;
 const { service } = inject;
 const { themes: themesList } = themes;
+
+const kPlayers = Object.keys( players );
 
 
 function settingsAttrMeta( attr, prop ) {
@@ -56,6 +61,34 @@ export default Controller.extend( RetryTransitionMixin, {
 	retryOpenDefault: settingsAttrMeta( "retry_open", "defaultValue" ),
 	retryOpenMin    : settingsAttrMeta( "retry_open", "min" ),
 	retryOpenMax    : settingsAttrMeta( "retry_open", "max" ),
+
+	playerPresets: computed(function() {
+		let presetList = kPlayers
+			.filter(function( key ) {
+				return players[ key ][ "exec" ][ platformName ]
+				    && players[ key ][ "disabled" ] !== true;
+			})
+			.map(function( key ) {
+				return {
+					id: key,
+					label: players[ key ][ "name" ]
+				};
+			});
+
+		presetList.unshift({
+			id   : "default",
+			label: "No preset"
+		});
+
+		return presetList;
+	}),
+
+	playerPresetFields: computed( "model.player_preset", function() {
+		let preset = get( this, "model.player_preset" );
+		if ( !preset || !players.hasOwnProperty( preset ) ) { return []; }
+
+		return players[ preset ][ "params" ];
+	}),
 
 
 	substitutionsPlayer: playerSubstitutions,

--- a/src/app/initializers/localstorage.js
+++ b/src/app/initializers/localstorage.js
@@ -1,4 +1,7 @@
-import { langs } from "config";
+import {
+	players,
+	langs
+} from "config";
 import qualities from "models/LivestreamerQualities";
 
 
@@ -37,6 +40,37 @@ function upgradeSettings() {
 
 	if ( settings.gui_homepage === "/user/following" ) {
 		settings.gui_homepage = "/user/followedStreams";
+	}
+
+	// translate old player data into the player presets format
+	if ( typeof settings.player === "string" ) {
+		settings.player = {
+			"default": {
+				"exec": settings[ "player" ] || "",
+				"args": settings[ "player_params" ] || ""
+			}
+		};
+		delete settings[ "player_params" ];
+	}
+
+	// make sure that default player params are set/updated once a new one gets added
+	if ( typeof settings.player === "object" ) {
+		Object.keys( players ).forEach(function( name ) {
+			if ( !settings.player.hasOwnProperty( name ) ) {
+				settings.player[ name ] = {
+					"exec": "",
+					"args": "",
+					"params": {}
+				};
+			}
+			let playerParams = settings.player[ name ].params;
+			// iterate player preset params
+			players[ name ].params.forEach(function( param ) {
+				// don't overwrite already existing values
+				if ( playerParams.hasOwnProperty( param.name ) ) { return; }
+				playerParams[ param.name ] = param.default;
+			});
+		});
 	}
 
 	var renamedProps = {

--- a/src/app/models/LivestreamerParameters.js
+++ b/src/app/models/LivestreamerParameters.js
@@ -61,13 +61,13 @@ export const parameters = [
 	new Parameter(
 		"--player",
 		null,
-		"settings.player",
+		"playerExec.exec",
 		playerSubstitutions
 	),
 	new Parameter(
 		"--player-args",
-		[ "settings.advanced", "settings.player" ],
-		"settings.playerParamsCorrected",
+		null,
+		"playerParams",
 		playerSubstitutions
 	),
 	new Parameter(

--- a/src/app/models/LivestreamerPlayerParameters.js
+++ b/src/app/models/LivestreamerPlayerParameters.js
@@ -1,0 +1,96 @@
+import { get } from "Ember";
+import { players } from "config";
+import whichFallback from "utils/node/fs/whichFallback";
+
+
+/**
+ * @param {Settings} settings
+ * @returns {Object[]}
+ */
+function getPlayerData( settings ) {
+	let player = get( settings, "player" );
+	let preset = get( settings, "player_preset" );
+
+	if ( !preset || !player.hasOwnProperty( preset ) ) {
+		preset = "default";
+	}
+
+	return [
+		// player settings
+		get( player, preset ) || {},
+		// player preset data
+		get( players, preset ) || {}
+	];
+}
+
+
+/**
+ * Resolve the player executable path and use fallbacks
+ * @param {Settings} settings
+ * @returns {Promise.<Object>}
+ */
+export function getPlayerExec( settings ) {
+	let [ playerSettings, playerPreset ] = getPlayerData( settings );
+	let exec = get( playerSettings, "exec" ) || get( playerPreset, "exec" ) || "";
+
+	// no player path or preset was selected
+	if ( exec === "" ) {
+		return Promise.resolve();
+	}
+
+	return whichFallback( exec, playerPreset.fallback )
+		.then(function( exec ) {
+			// return an object with an exec property for the EmberData.PromiseObject
+			return { exec };
+		})
+		.catch(function() {
+			return Promise.reject( new Error( "Unable to find player executable" ) );
+		});
+}
+
+
+/**
+ * Build the player parameter string out of the preset and custom params
+ * @param {Settings} settings
+ * @returns {String}
+ */
+export function getPlayerParams( settings ) {
+	let [ playerData, { params: playerPresetParams } ] = getPlayerData( settings );
+
+	let args = get( playerData, "args" ) || "";
+	let params = get( playerData, "params" ) || {};
+
+	// get the content of an ObjectBuffer
+	if ( params.getContent instanceof Function ) {
+		params = params.getContent();
+	}
+
+	// build the parameter preset string
+	let paramlist = Object.keys( params )
+		.map(function( param ) {
+			let paramObj = playerPresetParams.findBy( "name", param );
+			if ( !paramObj ) { return ""; }
+
+			switch ( paramObj.type ) {
+				case "boolean":
+					return params[ param ]
+						? paramObj.args
+						: null;
+				default:
+					return null;
+			}
+		})
+		.filter(function( item ) {
+			return item !== null;
+		});
+
+	// combine preset and custom params
+	let res = [ ...paramlist, args ].join( " " );
+
+	// fix missing {filename} variable
+	if ( res && res.indexOf( "{filename}" ) === -1 ) {
+		res = `${res} {filename}`;
+	}
+
+	return res;
+}

--- a/src/app/models/localstorage/Settings.js
+++ b/src/app/models/localstorage/Settings.js
@@ -6,7 +6,10 @@ import {
 	attr,
 	Model
 } from "EmberData";
-import { langs } from "config";
+import {
+	players,
+	langs
+} from "config";
 import qualities from "models/LivestreamerQualities";
 import { isWin } from "utils/node/platform";
 
@@ -22,6 +25,34 @@ function defaultQualityPresets() {
 	}, {} );
 }
 
+function defaultPlayerData() {
+	return Object.keys( players )
+		.map(function( player ) {
+			let params = players[ player ][ "params" ]
+				.reduce(function( obj, param ) {
+					obj[ param.name ] = param.default;
+					return obj;
+				}, {} );
+
+			return {
+				key: player,
+				exec: "",
+				args: "",
+				params: params
+			};
+		})
+		.reduce( function( obj, player ) {
+			obj[ player.key ] = player;
+			delete player.key;
+			return obj;
+		}, {
+			"default": {
+				exec: "",
+				args: ""
+			}
+		} );
+}
+
 function defaultLangFilterValue() {
 	return langCodes.reduce(function( obj, code ) {
 		if ( !langs[ code ].disabled ) {
@@ -32,6 +63,9 @@ function defaultLangFilterValue() {
 }
 
 
+/**
+ * @class Settings
+ */
 export default Model.extend({
 	advanced            : attr( "boolean", { defaultValue: false } ),
 	livestreamer        : attr( "string",  { defaultValue: "" } ),
@@ -39,8 +73,8 @@ export default Model.extend({
 	livestreamer_oauth  : attr( "boolean", { defaultValue: true } ),
 	quality             : attr( "string",  { defaultValue: "source" } ),
 	quality_presets     : attr( "",        { defaultValue: defaultQualityPresets } ),
-	player              : attr( "string",  { defaultValue: "" } ),
-	player_params       : attr( "string",  { defaultValue: "" } ),
+	player              : attr( "",        { defaultValue: defaultPlayerData } ),
+	player_preset       : attr( "string",  { defaultValue: "default" } ),
 	player_passthrough  : attr( "string",  { defaultValue: "http" } ),
 	player_reconnect    : attr( "boolean", { defaultValue: true } ),
 	player_no_close     : attr( "boolean", { defaultValue: false } ),
@@ -85,14 +119,6 @@ export default Model.extend({
 
 	isVisibleInTray: computed( "gui_integration", function() {
 		return ( get( this, "gui_integration" ) & 2 ) > 0;
-	}),
-
-	playerParamsCorrected: computed( "player_params", function() {
-		let params = get( this, "player_params" );
-
-		return params.length && params.indexOf( "{filename}" ) === -1
-			? `${params} {filename}`
-			: params;
 	})
 
 }).reopenClass({

--- a/src/app/utils/Parameter.js
+++ b/src/app/utils/Parameter.js
@@ -42,31 +42,29 @@ Parameter.prototype.validate = function( context ) {
 
 /**
  * @param {Object} context
- * @param {boolean} advanced
  * @returns {(string|boolean)}
  */
-Parameter.prototype.getValue = function( context, advanced ) {
+Parameter.prototype.getValue = function( context ) {
 	if ( isNone( this.value ) ) { return false; }
 
-	var value = String( get( context, this.value ) );
-	return advanced && this.subst
+	let value = String( get( context, this.value ) );
+	return this.subst
 		? Substitution.substitute( context, this.subst, value, true )
 		: value;
 };
 
 /**
  * @param {Object} context
- * @param {boolean} advanced
  * @returns {string[]}
  */
-Parameter.prototype.get = function( context, advanced ) {
-	var res = [];
+Parameter.prototype.get = function( context ) {
+	let res = [];
 
 	if ( !isNone( this.name ) ) {
 		res.push( this.name );
 	}
 
-	var value = this.getValue( context, advanced );
+	let value = this.getValue( context );
 	if ( value !== false && value.length ) {
 		res.push( value );
 	}
@@ -79,10 +77,9 @@ Parameter.prototype.get = function( context, advanced ) {
  * Turn an array of parameters into an array of strings in context of an object
  * @param {Object} context
  * @param {Parameter[]} parameters
- * @param {boolean?} advanced
  * @returns {string[]}
  */
-Parameter.getParameters = function( context, parameters, advanced ) {
+Parameter.getParameters = function( context, parameters ) {
 	return parameters
 		// a parameter must fulfill every condition
 		.filter(function( parameter ) {
@@ -90,7 +87,7 @@ Parameter.getParameters = function( context, parameters, advanced ) {
 		})
 		// return a list of each parameter's name and its (substituted) value
 		.reduce(function( arr, parameter ) {
-			var params = parameter.get( context, advanced );
+			let params = parameter.get( context );
 			arr.push( ...makeArray( params ) );
 
 			return arr;

--- a/src/config/players.json
+++ b/src/config/players.json
@@ -1,0 +1,142 @@
+{
+	"vlc": {
+		"exec": {
+			"win32": "vlc.exe",
+			"darwin": "VLC",
+			"linux": "vlc"
+		},
+		"fallback": {
+			"win32": [
+				"%PROGRAMFILES%\\VideoLAN\\VLC",
+				"%PROGRAMFILES(X86)%\\VideoLAN\\VLC"
+			],
+			"darwin": [
+				"/Applications/VLC.app/Contents/MacOS"
+			],
+			"linux": [
+				"/usr/bin",
+				"/usr/local/bin"
+			]
+		},
+		"params": [
+			{
+				"name": "Prevent single instance mode",
+				"descr": "View multiple streams in different player windows.",
+				"default": true,
+				"args": "--no-one-instance"
+			},
+			{
+				"name": "Allow Livestreamer to close the player",
+				"descr": "Prevents stacking up empty player windows.",
+				"default": true,
+				"args": "--play-and-exit"
+			},
+			{
+				"name": "Customize player window title",
+				"descr": "Show the channel name, game being played and stream title.",
+				"default": true,
+				"args": "--meta-title \"{name} - {game} - {status}\""
+			},
+			{
+				"name": "Disable player video cache",
+				"descr": "Reduces stream delay. Livestreamer already buffers the stream.",
+				"default": false,
+				"args": "--file-caching=0"
+			},
+			{
+				"name": "Minimal player layout",
+				"descr": "Hide player controls. Can also be toggled by pressing CTRL+H.",
+				"default": false,
+				"args": "--qt-minimal-view"
+			}
+		]
+	},
+	"mpv": {
+		"exec": {
+			"win32": "mpv.exe",
+			"darwin": "mpv",
+			"linux": "mpv"
+		},
+		"fallback": {
+			"win32": [
+				"%PROGRAMFILES%\\mpv",
+				"%PROGRAMFILES(X86)%\\mpv"
+			],
+			"darwin": [
+				"/Applications/mpv.app/Contents/MacOS",
+				"/usr/bin",
+				"/usr/local/bin"
+			],
+			"linux": [
+				"/usr/bin",
+				"/usr/local/bin"
+			]
+		},
+		"params": [
+			{
+				"name": "Allow Livestreamer to close the player",
+				"descr": "Prevents stacking up empty player windows.",
+				"default": true,
+				"args": "--keep-open=no"
+			},
+			{
+				"name": "Customize player window title",
+				"descr": "Show the channel name, game being played and stream title.",
+				"default": true,
+				"args": "--title \"{name} - {game} - {status}\""
+			},
+			{
+				"name": "Disable player video cache",
+				"descr": "Reduces stream delay. Livestreamer already buffers the stream.",
+				"default": false,
+				"args": "--no-cache"
+			},
+			{
+				"name": "Minimal player layout",
+				"descr": "Don't show player window decorations.",
+				"default": false,
+				"args": "--no-border"
+			},
+			{
+				"name": "Always show player window",
+				"descr": "Fixes potential issues with audio-only streams.",
+				"default": true,
+				"args": "--force-window"
+			}
+		]
+	},
+	"mpc": {
+		"exec": {
+			"win32": [
+				"mpc-hc64.exe",
+				"mpc-hc.exe"
+			],
+			"darwin": false,
+			"linux": false
+		},
+		"fallback": {
+			"win32": [
+				"%PROGRAMFILES%\\MPC-HC",
+				"%PROGRAMFILES(X86)%\\MPC-HC",
+				"%PROGRAMFILES%\\K-Lite Codec Pack\\MPC-HC64",
+				"%PROGRAMFILES%\\K-Lite Codec Pack\\MPC-HC",
+				"%PROGRAMFILES(X86)%\\K-Lite Codec Pack\\MPC-HC64",
+				"%PROGRAMFILES(X86)%\\K-Lite Codec Pack\\MPC-HC"
+			]
+		},
+		"params": [
+			{
+				"name": "Prevent single instance mode",
+				"descr": "View multiple streams in different player windows.",
+				"default": true,
+				"args": "/new"
+			},
+			{
+				"name": "Allow Livestreamer to close the player",
+				"descr": "Prevents stacking up empty player windows.",
+				"default": true,
+				"args": "/play /close"
+			}
+		]
+	}
+}

--- a/src/config/players.json
+++ b/src/config/players.json
@@ -1,5 +1,6 @@
 {
 	"vlc": {
+		"name": "VLC media player",
 		"exec": {
 			"win32": "vlc.exe",
 			"darwin": "VLC",
@@ -20,38 +21,41 @@
 		},
 		"params": [
 			{
-				"name": "Prevent single instance mode",
-				"descr": "View multiple streams in different player windows.",
+				"title": "Single instance mode",
+				"description": "View multiple streams in different player windows.",
+				"type": "boolean",
 				"default": true,
+				"text": "Prevent single instance mode",
 				"args": "--no-one-instance"
 			},
 			{
-				"name": "Allow Livestreamer to close the player",
-				"descr": "Prevents stacking up empty player windows.",
+				"title": "Close player",
+				"description": "Prevents stacking up empty player windows.",
+				"type": "boolean",
 				"default": true,
+				"text": "Allow Livestreamer to close the player",
 				"args": "--play-and-exit"
 			},
 			{
-				"name": "Customize player window title",
-				"descr": "Show the channel name, game being played and stream title.",
+				"title": "Player window title",
+				"description": "Show the channel name, game being played and stream title.",
+				"type": "boolean",
 				"default": true,
+				"text": "Set custom title",
 				"args": "--meta-title \"{name} - {game} - {status}\""
 			},
 			{
-				"name": "Disable player video cache",
-				"descr": "Reduces stream delay. Livestreamer already buffers the stream.",
+				"title": "Layout",
+				"description": "Hide player controls. Can also be toggled by pressing CTRL+H.",
+				"type": "boolean",
 				"default": false,
-				"args": "--file-caching=0"
-			},
-			{
-				"name": "Minimal player layout",
-				"descr": "Hide player controls. Can also be toggled by pressing CTRL+H.",
-				"default": false,
+				"text": "Minimal player layout",
 				"args": "--qt-minimal-view"
 			}
 		]
 	},
 	"mpv": {
+		"name": "MPV",
 		"exec": {
 			"win32": "mpv.exe",
 			"darwin": "mpv",
@@ -74,38 +78,41 @@
 		},
 		"params": [
 			{
-				"name": "Allow Livestreamer to close the player",
-				"descr": "Prevents stacking up empty player windows.",
+				"title": "Close player",
+				"description": "Prevents stacking up empty player windows.",
+				"type": "boolean",
 				"default": true,
+				"text": "Allow Livestreamer to close the player",
 				"args": "--keep-open=no"
 			},
 			{
-				"name": "Customize player window title",
-				"descr": "Show the channel name, game being played and stream title.",
+				"title": "Player window title",
+				"description": "Show the channel name, game being played and stream title.",
+				"type": "boolean",
 				"default": true,
+				"text": "Set custom title",
 				"args": "--title \"{name} - {game} - {status}\""
 			},
 			{
-				"name": "Disable player video cache",
-				"descr": "Reduces stream delay. Livestreamer already buffers the stream.",
+				"title": "Layout",
+				"description": "Don't show player window decorations.",
+				"type": "boolean",
 				"default": false,
-				"args": "--no-cache"
-			},
-			{
-				"name": "Minimal player layout",
-				"descr": "Don't show player window decorations.",
-				"default": false,
+				"text": "Minimal player layout",
 				"args": "--no-border"
 			},
 			{
-				"name": "Always show player window",
-				"descr": "Fixes potential issues with audio-only streams.",
+				"title": "Force window",
+				"description": "Fixes potential issues with audio-only streams.",
+				"type": "boolean",
 				"default": true,
+				"text": "Always show player window",
 				"args": "--force-window"
 			}
 		]
 	},
 	"mpc": {
+		"name": "Media Player Classic - Home Cinema",
 		"exec": {
 			"win32": [
 				"mpc-hc64.exe",
@@ -128,15 +135,19 @@
 		},
 		"params": [
 			{
-				"name": "Prevent single instance mode",
-				"descr": "View multiple streams in different player windows.",
+				"title": "Single instance mode",
+				"description": "View multiple streams in different player windows.",
+				"type": "boolean",
 				"default": true,
+				"text": "Prevent single instance mode",
 				"args": "/new"
 			},
 			{
-				"name": "Allow Livestreamer to close the player",
-				"descr": "Prevents stacking up empty player windows.",
+				"title": "Close player",
+				"description": "Prevents stacking up empty player windows.",
+				"type": "boolean",
 				"default": true,
+				"text": "Allow Livestreamer to close the player",
 				"args": "/play /close"
 			}
 		]

--- a/src/config/players.json
+++ b/src/config/players.json
@@ -171,5 +171,23 @@
 				"args": "/play /close"
 			}
 		]
+	},
+	"potplayer": {
+		"name": "Daum PotPlayer",
+		"exec": {
+			"win32": [
+				"PotPlayerMini64.exe",
+				"PotPlayerMini.exe"
+			],
+			"darwin": false,
+			"linux": false
+		},
+		"fallback": {
+			"win32": [
+				"%PROGRAMFILES%\\DAUM\\PotPlayer",
+				"%PROGRAMFILES(X86)%\\DAUM\\PotPlayer"
+			]
+		},
+		"params": []
 	}
 }

--- a/src/config/players.json
+++ b/src/config/players.json
@@ -121,7 +121,9 @@
 				"%PROGRAMFILES%\\K-Lite Codec Pack\\MPC-HC64",
 				"%PROGRAMFILES%\\K-Lite Codec Pack\\MPC-HC",
 				"%PROGRAMFILES(X86)%\\K-Lite Codec Pack\\MPC-HC64",
-				"%PROGRAMFILES(X86)%\\K-Lite Codec Pack\\MPC-HC"
+				"%PROGRAMFILES(X86)%\\K-Lite Codec Pack\\MPC-HC",
+				"%PROGRAMFILES%\\K-Lite Codec Pack\\Media Player Classic",
+				"%PROGRAMFILES(X86)%\\K-Lite Codec Pack\\Media Player Classic"
 			]
 		},
 		"params": [

--- a/src/config/players.json
+++ b/src/config/players.json
@@ -21,32 +21,40 @@
 		},
 		"params": [
 			{
+				"name": "instance",
 				"title": "Single instance mode",
 				"description": "View multiple streams in different player windows.",
+				"icon": "fa-clone",
 				"type": "boolean",
 				"default": true,
 				"text": "Prevent single instance mode",
 				"args": "--no-one-instance"
 			},
 			{
+				"name": "close",
 				"title": "Close player",
 				"description": "Prevents stacking up empty player windows.",
+				"icon": "fa-times",
 				"type": "boolean",
 				"default": true,
 				"text": "Allow Livestreamer to close the player",
 				"args": "--play-and-exit"
 			},
 			{
+				"name": "title",
 				"title": "Player window title",
 				"description": "Show the channel name, game being played and stream title.",
+				"icon": "fa-font",
 				"type": "boolean",
 				"default": true,
 				"text": "Set custom title",
 				"args": "--meta-title \"{name} - {game} - {status}\""
 			},
 			{
+				"name": "minimal",
 				"title": "Layout",
 				"description": "Hide player controls. Can also be toggled by pressing CTRL+H.",
+				"icon": "fa-image",
 				"type": "boolean",
 				"default": false,
 				"text": "Minimal player layout",
@@ -78,32 +86,40 @@
 		},
 		"params": [
 			{
+				"name": "close",
 				"title": "Close player",
 				"description": "Prevents stacking up empty player windows.",
+				"icon": "fa-times",
 				"type": "boolean",
 				"default": true,
 				"text": "Allow Livestreamer to close the player",
 				"args": "--keep-open=no"
 			},
 			{
+				"name": "title",
 				"title": "Player window title",
 				"description": "Show the channel name, game being played and stream title.",
+				"icon": "fa-font",
 				"type": "boolean",
 				"default": true,
 				"text": "Set custom title",
 				"args": "--title \"{name} - {game} - {status}\""
 			},
 			{
+				"name": "minimal",
 				"title": "Layout",
 				"description": "Don't show player window decorations.",
+				"icon": "fa-square-o",
 				"type": "boolean",
 				"default": false,
 				"text": "Minimal player layout",
 				"args": "--no-border"
 			},
 			{
+				"name": "window",
 				"title": "Force window",
 				"description": "Fixes potential issues with audio-only streams.",
+				"icon": "fa-image",
 				"type": "boolean",
 				"default": true,
 				"text": "Always show player window",
@@ -135,16 +151,20 @@
 		},
 		"params": [
 			{
+				"name": "instance",
 				"title": "Single instance mode",
 				"description": "View multiple streams in different player windows.",
+				"icon": "fa-clone",
 				"type": "boolean",
 				"default": true,
 				"text": "Prevent single instance mode",
 				"args": "/new"
 			},
 			{
+				"name": "close",
 				"title": "Close player",
 				"description": "Prevents stacking up empty player windows.",
+				"icon": "fa-times",
 				"type": "boolean",
 				"default": true,
 				"text": "Allow Livestreamer to close the player",

--- a/src/styles/routes/Settings.less
+++ b/src/styles/routes/Settings.less
@@ -99,4 +99,8 @@
 			cursor: default;
 		}
 	}
+
+	.player-preset-dropdown {
+		max-width: 20rem;
+	}
 }

--- a/src/templates/settings/SettingsPlayer.hbs
+++ b/src/templates/settings/SettingsPlayer.hbs
@@ -4,7 +4,7 @@
 	"Use a predefined player configuration."
 	icon="fa-play-circle-o"
 }}
-	{{drop-down value=model.player_preset content=playerPresets}}
+	{{drop-down value=model.player_preset content=playerPresets class="player-preset-dropdown"}}
 {{/settings-row}}
 
 {{#settings-row

--- a/src/templates/settings/SettingsPlayer.hbs
+++ b/src/templates/settings/SettingsPlayer.hbs
@@ -22,31 +22,30 @@
 	}}
 {{/settings-row}}
 
-{{#unless (is-equal model.player_preset "")}}
-	{{#each playerPresetFields as |field|}}
-		{{#settings-row
-			field.title
-			field.description
-			icon=(if field.icon
-				field.icon
-				(get
-					(hash
-						boolean="fa-check"
-					)
-					field.type
+{{#each playerPresetFields as |field|}}
+	{{#settings-row
+		field.title
+		field.description
+		icon=(if field.icon
+			field.icon
+			(get
+				(hash
+					boolean="fa-check"
 				)
+				field.type
 			)
-			command=field.args
-		}}
-			{{#if (is-equal field.type "boolean")}}
-				{{check-box
-					(if field.text field.text field.title)
-					checked=(mut (get (get (get model.player model.player_preset) "params") field.name))
-				}}
-			{{/if}}
-		{{/settings-row}}
-	{{/each}}
-{{/unless}}
+		)
+		command=field.args
+		isVisible=(is-equal field.preset model.player_preset)
+	}}
+		{{#if (is-equal field.type "boolean")}}
+			{{check-box
+				(if field.text field.text field.title)
+				checked=(mut (get (get (get model.player model.player_preset) "params") field.name))
+			}}
+		{{/if}}
+	{{/settings-row}}
+{{/each}}
 
 {{#settings-row
 	(if (is-equal model.player_preset "default") "Parameters" "Custom parameters")

--- a/src/templates/settings/SettingsPlayer.hbs
+++ b/src/templates/settings/SettingsPlayer.hbs
@@ -1,33 +1,73 @@
 <fieldset>
 {{#settings-row
-	"Videoplayer"
-	"Path to the player executable."
+	"Player preset"
+	"Use a predefined player configuration."
+	icon="fa-play-circle-o"
+}}
+	{{drop-down value=model.player_preset content=playerPresets}}
+{{/settings-row}}
+
+{{#settings-row
+	(if (is-equal model.player_preset "default") "Video player" "Player executable")
+	"Path to the player executable or its name if it can be found in $PATH."
 	icon="fa-tv"
 	documentation="--player"
 	substitutions=(if model.advanced substitutionsPlayer)
 	notes=(if model.advanced "Parameters can be added here, but should be set in the parameters field instead.")
 }}
-	{{file-select value=model.player inputClass="form-control" placeholder="Leave blank for default player"}}
+	{{file-select
+		value=(mut (get (get model.player model.player_preset) "exec"))
+		inputClass="form-control"
+		placeholder=(if (is-equal model.player_preset "default") "Leave blank for default player" "Leave blank for default location")
+	}}
 {{/settings-row}}
 
-{{#if model.advanced}}
-	{{#settings-row
-		"Parameters"
-		"Add player specific parameters."
-		icon="fa-terminal"
-		documentation="--player-args"
-		substitutions=substitutionsPlayer
-	}}
-		{{input type="text" value=model.player_params classNames="col-xs-12" placeholder="Add custom player parameters"}}
-	{{/settings-row}}
-{{/if}}
+{{#unless (is-equal model.player_preset "")}}
+	{{#each playerPresetFields as |field|}}
+		{{#settings-row
+			field.title
+			field.description
+			icon=(if field.icon
+				field.icon
+				(get
+					(hash
+						boolean="fa-check"
+					)
+					field.type
+				)
+			)
+			command=field.args
+		}}
+			{{#if (is-equal field.type "boolean")}}
+				{{check-box
+					(if field.text field.text field.title)
+					checked=(mut (get (get (get model.player model.player_preset) "params") field.name))
+				}}
+			{{/if}}
+		{{/settings-row}}
+	{{/each}}
+{{/unless}}
 
 {{#settings-row
-	"Close player"
+	(if (is-equal model.player_preset "default") "Parameters" "Custom parameters")
+	(if (is-equal model.player_preset "default") "Add player specific parameters." "Set additional custom player parameters.")
+	icon="fa-terminal"
+	documentation="--player-args"
+	substitutions=substitutionsPlayer
+}}
+	{{input
+		type="text"
+		classNames="col-xs-12"
+		value=(mut (get (get model.player model.player_preset) "args"))
+		placeholder="Add custom player parameters"
+	}}
+{{/settings-row}}
+
+{{#settings-row
+	"Keep player window"
 	"After the stream has ended."
-	icon="fa-times"
+	icon="fa-caret-square-o-right"
 	documentation="--player-no-close"
-	notes="The player itself may prevent this."
 }}
 	{{check-box "Do not close the player" checked=model.player_no_close}}
 {{/settings-row}}

--- a/src/test/tests/parameters.js
+++ b/src/test/tests/parameters.js
@@ -245,12 +245,6 @@ test( "Substituted parameters", function( assert ) {
 	);
 
 	assert.deepEqual(
-		getParams( obj, [ param ], false ),
-		[ "--param", "{foo} \"{bar}\" \'{baz}\'" ],
-		"Disabled parameter value substitution"
-	);
-
-	assert.deepEqual(
 		getParams( obj, [ paramTitleA ], true ),
 		[ "--player-args", "--title \"foo's \\\"bar\\\" \\\\\"" ],
 		"Only escape double quote chars in double quote strings"


### PR DESCRIPTION
This adds a list of known players and parameters, so that users don't need to specify these by themself and certain player behaviors can be forced. Most of the users will never set player parameters and some will use them incorrectly. Having a list of known parameters and a default configuration for each player will solve multiple issues.

- [x] **Give each player a set of default locations for each platform.**  
  Use these as a fallback and let the user set custom paths.
- [x] **Define a list of useful player parameters.**  
  Player behavior, player window title, buffering/caching, etc.
- [x] **Add preset/parameter selection to the player settings menu.**  
  Tell users about each parameter and give them control over each one.
- [x] **Allow users to define custom parameters as well.**  
  In addition to (as a replacement of) the enabled parameters.

#### Players
- [x] VLC
- [x] MPV
- [x] MPC-HC
