### PR TITLE
Streamlink Twitch GUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Changelog - Livestreamer Twitch GUI
+Changelog - Streamlink Twitch GUI
 ===
 
 ## Master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ Changelog - Streamlink Twitch GUI
 
 ## Master
 
+**"Livestreamer Twitch GUI" is now "Streamlink Twitch GUI"**
+
+The application has been renamed and moved to [Streamlink](https://github.com/streamlink/streamlink).  
+Streamlink is a fork of Livestreamer with active development.
+
+Livestreamer will continue to work, but please have in mind that support may be dropped at any time. Streamlink installation instructions can be found [here](https://streamlink.github.io/install.html).
+
+Please be aware that the name of the application's config folder has changed. Informations on how to migrate the old data can be found in the [Wiki](https://github.com/streamlink/streamlink-twitch-gui/wiki).
+
+
 - Upgraded from legacy NW.js (v0.12.3) to latest stable version (v0.18.8). #275
 - Implemented system for switching between Streamlink and Livestreamer. #331  
   Please re-validate your Streamlink/Livestreamer settings (default is Streamlink).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,10 @@ Please be aware that the name of the application's config folder has changed. In
 - Upgraded to Ember/EmberData 2.9
 
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.16.0...master)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.16.0...master)
 
 
-## [v0.16.0](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.16.0) (2016-10-15)
+## [v0.16.0](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.16.0) (2016-10-15)
 
 - Added initial support for Streamlink (in addition to Livestreamer).  
   See "The future of Livestreamer Twitch GUI" (#331) for more infos.
@@ -50,28 +50,28 @@ Please be aware that the name of the application's config folder has changed. In
 - Upgraded to Ember/EmberData 2.8.
 
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.15.2...v0.16.0)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.15.2...v0.16.0)
 
 
-## [v0.15.2](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.15.2) (2016-09-16)
+## [v0.15.2](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.15.2) (2016-09-16)
 
 - Fixed InfiniteScrollMixin using invalid request offsets when refreshing or revisiting the same route. #314
 
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.15.1...v0.15.2)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.15.1...v0.15.2)
 
 
-## [v0.15.1](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.15.1) (2016-09-15)
+## [v0.15.1](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.15.1) (2016-09-15)
 
 - Implemented a better workaround for the Livestreamer Client-ID issue. #310
 - Added option to disable Livestreamer authentication. #308
 - Fixed tray icon being invisible on Windows. #312
 
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.15.0...v0.15.1)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.15.0...v0.15.1)
 
 
-## [v0.15.0](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.15.0) (2016-09-15)
+## [v0.15.0](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.15.0) (2016-09-15)
 
 - Added authentication check to the stream launch routine (see below). #310
 - Added support for custom channel names. #303
@@ -86,19 +86,19 @@ The only workaround for this missing change is forcing all users to log in and l
 Please also see #289 if you think you can help with the organization of a Livestreamer fork. There are several bugs that need to be fixed and some features/ideas that need to be implemented for a better experience. This will benefit all Livestreamer and Livestreamer Twitch GUI users, thank you!
 
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.14.2...v0.15.0)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.14.2...v0.15.0)
 
 
-## [v0.14.2](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.14.2) (2016-08-08)
+## [v0.14.2](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.14.2) (2016-08-08)
 
 - Added 1080p60 quality as fallback to source.  
   Fixes dota2ti streams not working. #283
 
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.14.1...v0.14.2)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.14.1...v0.14.2)
 
 
-## [v0.14.1](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.14.1) (2016-08-03)
+## [v0.14.1](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.14.1) (2016-08-03)
 
 - Fixed application launch bug. #278
 - Fixed broken custom Chromium/Chrome executable paths. #270
@@ -109,10 +109,10 @@ Please also see #289 if you think you can help with the organization of a Livest
   https://blog.twitch.tv/-705404e95cc2
 
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.14.0...v0.14.1)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.14.0...v0.14.1)
 
 
-## [v0.14.0](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.14.0) (2016-07-11)
+## [v0.14.0](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.14.0) (2016-07-11)
 
 - Include ClientID in all API requests.  
   See https://blog.twitch.tv/-afbb8e95f843
@@ -133,10 +133,10 @@ Please also see #289 if you think you can help with the organization of a Livest
 - Fixed reloading initial error routes.
 
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.13.0...v0.14.0)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.13.0...v0.14.0)
 
 
-## [v0.13.0](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.13.0) (2016-03-30)
+## [v0.13.0](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.13.0) (2016-03-30)
 
 - Implemented hosted streams. #220
 - Implemented detection of duplicated items in infinite scroll lists. #216
@@ -153,19 +153,19 @@ Please also see #289 if you think you can help with the organization of a Livest
 - Fixed infinite scroll on unscaled UHD resolutions. #230
 - Upgraded to Ember/EmberData 2.4.0 LTS
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.12.0...v0.13.0)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.12.0...v0.13.0)
 
 
-## [v0.12.0](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.12.0) (2016-02-06)
+## [v0.12.0](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.12.0) (2016-02-06)
 
 - Re-implemented the authentication system. #209
 - Improved desktop notification failure detection.
 - Fixed OSX cmd+r refresh shortcut. #203
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.11.2...v0.12.0)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.11.2...v0.12.0)
 
 
-## [v0.11.2](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.11.2) (2016-01-23)
+## [v0.11.2](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.11.2) (2016-01-23)
 
 - Implemented right click context menus. #180
 - Implemented additional stream click actions. #180
@@ -178,10 +178,10 @@ Please also see #289 if you think you can help with the organization of a Livest
 - Fixed bug causing scrolling to stop working. #196
 - Fixed blurry application icon on Linux.
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.11.1...v0.11.2)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.11.1...v0.11.2)
 
 
-## [v0.11.1](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.11.1) (2015-12-05)
+## [v0.11.1](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.11.1) (2015-12-05)
 
 - Implemented channel details.
 - Changed details view in stream list items.
@@ -193,10 +193,10 @@ Please also see #289 if you think you can help with the organization of a Livest
 - Fixed image preloading system issue.
 - Upgraded to Ember/EmberData 2.1.0.
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.11.0...v0.11.1)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.11.0...v0.11.1)
 
 
-## [v0.11.0](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.11.0) (2015-10-16)
+## [v0.11.0](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.11.0) (2015-10-16)
 
 - Implemented theme switcher and added dark theme.
 - Implemented menu-related random stream launch button.
@@ -208,19 +208,19 @@ Please also see #289 if you think you can help with the organization of a Livest
 - Fixed subscribe button being visible on all channel pages / popups. #142
 - Fixed text of closing modal dialog.
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.10.1...v0.11.0)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.10.1...v0.11.0)
 
 
-## [v0.10.1](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.10.1) (2015-09-14)
+## [v0.10.1](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.10.1) (2015-09-14)
 
 - Fixed livestreamer validation.
 - Fixed image preloader.
 - Fixed application name in gnome panel. #136
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.10.0...v0.10.1)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.10.0...v0.10.1)
 
 
-## [v0.10.0](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.10.0) (2015-09-13)
+## [v0.10.0](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.10.0) (2015-09-13)
 
 - Implemented multiple chat methods. #132
 - Implemented real stream language filters. #133
@@ -233,20 +233,20 @@ Please also see #289 if you think you can help with the organization of a Livest
 - Several bug fixes and improvements.
 - Upgraded application to Ember/Ember-Data 2.0.
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.9.3...v0.10.0)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.9.3...v0.10.0)
 
 
-## [v0.9.3](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.9.3) (2015-08-05)
+## [v0.9.3](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.9.3) (2015-08-05)
 
 - Fixed livestreamer validation failure on OSX. #121
 - Fixed minimize to tray. #122
 - Always show chat button on channel pages. #119
 - Upgraded to NW.js v0.12.3.
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.9.2...v0.9.3)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.9.2...v0.9.3)
 
 
-## [v0.9.2](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.9.2) (2015-07-31)
+## [v0.9.2](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.9.2) (2015-07-31)
 
 - Implemented stream language filters. #113
 - Fully implemented the game following feature. #31
@@ -257,18 +257,18 @@ Please also see #289 if you think you can help with the organization of a Livest
 - Upgraded to NW.js v0.12.2.
 - Some minor bug fixes and improvements.
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.9.1...v0.9.2)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.9.1...v0.9.2)
 
 
-## [v0.9.1](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.9.1) (2015-05-27)
+## [v0.9.1](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.9.1) (2015-05-27)
 
 - Fixed desktop notifications.
 - Added a second livestreamer fallback path on OSX. #99
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.9.0...v0.9.1)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.9.0...v0.9.1)
 
 
-## [v0.9.0](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.9.0) (2015-05-25)
+## [v0.9.0](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.9.0) (2015-05-25)
 
 - Restructured mainmenu (renamed "Your" to "My"):
   - Implemented subscriptions and followed channels+games menus.
@@ -284,10 +284,10 @@ Please also see #289 if you think you can help with the organization of a Livest
 - Upgraded to Ember-Data 1.0.0-beta.17.
 - Several bug fixes and improvements.
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.8.0...v0.9.0)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.8.0...v0.9.0)
 
 
-## [v0.8.0](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.8.0) (2015-04-23)
+## [v0.8.0](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.8.0) (2015-04-23)
 
 - Implemented custom channel settings (see the wrench icon in the upper right corner). #23, #63
 - Implemented channel search function.
@@ -303,19 +303,19 @@ Please also see #289 if you think you can help with the organization of a Livest
 - Upgraded NW.js to v0.12.1 (fixes the HiDPI issues on Windows). #72
 - Several minor bug fixes and improvements.
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.7.3...v0.8.0)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.7.3...v0.8.0)
 
 
-## [v0.7.3](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.7.3) (2015-03-29)
+## [v0.7.3](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.7.3) (2015-03-29)
 
 - Fixed application being hidden after closing it while being minimized. #62
 - Replaced colored tray icons on OSX with grayscale ones.
 - Fixed notification click bug where chat was opened twice in some cases.
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.7.2...v0.7.3)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.7.2...v0.7.3)
 
 
-## [v0.7.2](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.7.2) (2015-03-26)
+## [v0.7.2](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.7.2) (2015-03-26)
 
 - Implemented channel pages.
 - Implemented login via OAuth token. #53  
@@ -332,10 +332,10 @@ Please also see #289 if you think you can help with the organization of a Livest
 - Upgraded NW.js to v0.12.0.
 - Various other bugfixes and improvements.
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.7.1...v0.7.2)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.7.1...v0.7.2)
 
 
-## [v0.7.1](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.7.1) (2015-02-10)
+## [v0.7.1](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.7.1) (2015-02-10)
 
 - Fixed "Launching stream" dialog being stuck in some cases. See #45 and #38. Thanks @Wraul
 - Fixed invalid aspect ratio of broken preview images.
@@ -343,10 +343,10 @@ Please also see #289 if you think you can help with the organization of a Livest
 - Changed default application font to Roboto.
 - Some other bugfixes
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.7.0...v0.7.1)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.7.0...v0.7.1)
 
 
-## [v0.7.0](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.7.0) (2015-01-22)
+## [v0.7.0](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.7.0) (2015-01-22)
 
 - Added x64 builds for Windows and OSX (see below).
 - Implemented follow-channel mechanics.
@@ -366,10 +366,10 @@ Please also see #289 if you think you can help with the organization of a Livest
 - Upgraded to latest stable version of nw.js (node-webkit) v0.11.6.
 - Various other bugfixes and improvements.
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.6.1...v0.7.0)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.6.1...v0.7.0)
 
 
-## [v0.6.1](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.6.1) (2014-12-12)
+## [v0.6.1](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.6.1) (2014-12-12)
 
 - **Set the required livestreamer version to v1.11.1 !!!** See #30  
   Twitch had changed their API lately, so livestreamer was unable to launch any streams. This means that you need to [install the latest livestreamer version](https://github.com/chrippa/livestreamer/releases) in order to watch twitch.tv streams. If you're running the old version, the GUI will prompt you to do so.
@@ -388,10 +388,10 @@ Please also see #289 if you think you can help with the organization of a Livest
   - clicking a livestreamer documentation link
   - featured streams having no status text
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.6.0...v0.6.1)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.6.0...v0.6.1)
 
 
-## [v0.6.0](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.6.0) (2014-11-15)
+## [v0.6.0](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.6.0) (2014-11-15)
 
 - Implemented twitch.tv login (due to dependency issues, only the followed channels are currently supported #27)
 - Improved the infinite scroll logic and stream tile layout
@@ -404,10 +404,10 @@ Please also see #289 if you think you can help with the organization of a Livest
 - Updated node-webkit to v0.11.0 (adds support for high-dpi)
 - Many other small fixes and improvements
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.5.0...v0.6.0)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.5.0...v0.6.0)
 
 
-## [v0.5.0](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.5.0) (2014-08-19)
+## [v0.5.0](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.5.0) (2014-08-19)
 
 - Multi stream support! #13
 - The GUI may now be closed while streams are still running
@@ -421,10 +421,10 @@ Please also see #289 if you think you can help with the organization of a Livest
 - Made the error messages a bit more informative
 - Added application icon for windows
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.4.2...v0.5.0)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.4.2...v0.5.0)
 
 
-## [v0.4.2](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.4.2) (2014-08-07)
+## [v0.4.2](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.4.2) (2014-08-07)
 
 * Added chat button to the "now watching" popup #9
 * Added quality change dropdown to the popup #10
@@ -437,68 +437,68 @@ Please also see #289 if you think you can help with the organization of a Livest
 * Linux builds now include scripts for adding a launcher to the menu
 * Added app-icons to OSX and Linux builds
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.4.1...v0.4.2)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.4.1...v0.4.2)
 
 
-## [v0.4.1](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.4.1) (2014-06-04)
+## [v0.4.1](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.4.1) (2014-06-04)
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.4.0...v0.4.1)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.4.0...v0.4.1)
 
 
-## [v0.4.0](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.4.0) (2014-05-11)
+## [v0.4.0](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.4.0) (2014-05-11)
 
 * Implemented the search function
 * Added startscript for linux users
 * Split up the build task into `release` and `dev`. See changelog
 * Added test for checking if livestreamer is set up correctly
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.3.1...v0.4.0)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.3.1...v0.4.0)
 
 ![image](https://cloud.githubusercontent.com/assets/467294/2937991/b94283f2-d8e8-11e3-9636-1824d17f757a.png)
 
 
-## [v0.3.1](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.3.1) (2014-05-07)
+## [v0.3.1](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.3.1) (2014-05-07)
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.3.0...v0.3.1)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.3.0...v0.3.1)
 
 
-## [v0.3.0](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.3.0) (2014-02-18)
+## [v0.3.0](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.3.0) (2014-02-18)
 
 Completely redesigned the app!
 
 Switched to a more neutral style and also removed the scaling layout. There are some elements (like the search bar) which are not yet implemented. These will be added in later releases.
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.2.3...v0.3.0)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.2.3...v0.3.0)
 
 ![image](https://f.cloud.github.com/assets/467294/2199101/065a5a3c-98d1-11e3-810d-73f7ba8859ca.png)
 
 
-## [v0.2.3](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.2.3) (2014-02-12)
+## [v0.2.3](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.2.3) (2014-02-12)
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.2.2...v0.2.3)
-
-
-## [v0.2.2](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.2.2) (2014-02-07)
-
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.2.1...v0.2.2)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.2.2...v0.2.3)
 
 
-## [v0.2.1](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.2.1) (2013-12-30)
+## [v0.2.2](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.2.2) (2014-02-07)
+
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.2.1...v0.2.2)
+
+
+## [v0.2.1](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.2.1) (2013-12-30)
 
 Just a patch release, no new features.
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.2.0...v0.2.1)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.2.0...v0.2.1)
 
 
-## [v0.2.0](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.2.0) (2013-12-21)
+## [v0.2.0](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.2.0) (2013-12-21)
 
 In this release I've added the settings menu so you can now set the path to where you've installed livestreamer to. You can also change the default stream quality.
 There is currently no validation of the user input and some more fields for customizing the videoplayer are disabled for now. I'm planning to add those things (and also the ability to choose the quality by each stream individually) in the next releases, but thats it for now.
 
-[Changelog](https://github.com/bastimeyer/livestreamer-twitch-gui/compare/v0.1.0...v0.2.0)
+[Changelog](https://github.com/streamlink/streamlink-twitch-gui/compare/v0.1.0...v0.2.0)
 
 
-## [v0.1.0](https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v0.1.0) (2013-12-13)
+## [v0.1.0](https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v0.1.0) (2013-12-13)
 
 There is not much to see, just some core functionality and some design ideas.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Livestreamer Twitch GUI
+# Contributing to Streamlink Twitch GUI
 
 Want to get involved? Thanks! There are plenty of ways to help!
 
@@ -25,7 +25,7 @@ Feature requests are welcome. But take a moment to find out whether your idea fi
 
 ## Developing and building
 
-Livestreamer Twitch GUI is based on [NW.js][NW.js].  
+Streamlink Twitch GUI is based on [NW.js][NW.js].  
 Please visit the [NW.js website][NW.js-website] if you want to know more about NW.js apps.
 
 Building the application is simple. Please ensure that the latest stable versions of [Git][Git], [Node.js][Node.js] and [Npm][npm] (bundled with Node.js) are installed on your system, so all dependencies can be installed and the application can be built and compiled.
@@ -34,8 +34,8 @@ Building the application is simple. Please ensure that the latest stable version
 
 ```bash
 # clone the repository
-git clone https://github.com/bastimeyer/livestreamer-twitch-gui.git
-cd livestreamer-twitch-gui
+git clone https://github.com/streamlink/streamlink-twitch-gui.git
+cd streamlink-twitch-gui
 
 # globally install grunt-cli and bower - may require administrator privileges
 npm install -g grunt-cli bower
@@ -44,7 +44,7 @@ npm install -g grunt-cli bower
 npm install
 ```
 
-Livestreamer Twitch GUI uses [Gruntjs][Gruntjs] and [Webpack][Webpack] as build tools.  
+Streamlink Twitch GUI uses [Gruntjs][Gruntjs] and [Webpack][Webpack] as build tools.  
 To get a list of all available grunt tasks, run `grunt --help`.  
 All task configs can be found in `build/tasks/{configs,custom}`.
 
@@ -90,11 +90,11 @@ Adhering to the following process is the best way to get your work included in t
 1. [Fork][howto-fork] the project, clone your fork, and configure the remotes:
    ```bash
    # Clone your fork of the repo into the current directory
-   git clone git@github.com:<YOUR-USERNAME>/livestreamer-twitch-gui.git
+   git clone git@github.com:<YOUR-USERNAME>/streamlink-twitch-gui.git
    # Navigate to the newly cloned directory
-   cd livestreamer-twitch-gui
+   cd streamlink-twitch-gui
    # Assign the original repo to a remote called "upstream"
-   git remote add upstream https://github.com/bastimeyer/livestreamer-twitch-gui.git
+   git remote add upstream https://github.com/streamlink/streamlink-twitch-gui.git
    ```
 
 2. If you cloned a while ago, get the latest changes from upstream
@@ -131,9 +131,9 @@ under the terms of the [MIT License][license].
 This contributing guide has been adapted from [HTML5 boilerplate's guide][ref-h5bp].
 
 
-  [license]: https://github.com/bastimeyer/livestreamer-twitch-gui/blob/master/LICENSE
-  [issues]: https://github.com/bastimeyer/livestreamer-twitch-gui/issues
-  [issue-template]: https://github.com/bastimeyer/livestreamer-twitch-gui/blob/master/ISSUE_TEMPLATE.md
+  [license]: https://github.com/streamlink/streamlink-twitch-gui/blob/master/LICENSE
+  [issues]: https://github.com/streamlink/streamlink-twitch-gui/issues
+  [issue-template]: https://github.com/streamlink/streamlink-twitch-gui/blob/master/ISSUE_TEMPLATE.md
   [howto-fork]: https://help.github.com/articles/fork-a-repo
   [howto-rebase]: https://help.github.com/articles/interactive-rebase
   [howto-format-commits]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Streamlink Twitch GUI
 [![Streamlink Twitch GUI][Preview]][Releases]
 
 
+## The application has been renamed
+
+*Streamlink Twitch GUI*, previously known as *Livestreamer Twitch GUI*, has been renamed in early december 2016. A statement about this change can be found in the thread ["The future of Livestreamer Twitch GUI"][Application-rename].
+
+
 ## Description
 
 This is a graphical user interface (GUI) on top of the [Streamlink][Streamlink] command line interface (CLI).  
@@ -111,3 +116,4 @@ Every contribution is welcome! Please read [CONTRIBUTING.md][Contributing] first
   [Package-AUR]: https://aur.archlinux.org/packages/streamlink-twitch-gui "AUR stable package"
   [Package-AUR-git]: https://aur.archlinux.org/packages/streamlink-twitch-gui-git "AUR git package"
   [Package-Homebrew-cask]: https://caskroom.github.io/
+  [Application-rename]: https://github.com/streamlink/streamlink-twitch-gui/issues/331 "The future of Livestreamer Twitch GUI"

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-Livestreamer Twitch GUI
+Streamlink Twitch GUI
 ===
 [![Supported platforms][badge-platforms]][Releases] [![Latest release][badge-release]][Releases] [![Open issues][badge-issues]][Issues] [![Gitter IRC][badge-gitter]][Gitter]
 
-**A multi platform [Twitch.tv][Twitch] browser for [Livestreamer][Livestreamer]**
+**A multi platform [Twitch.tv][Twitch] browser for [Streamlink][Streamlink]**
 
-[![Livestreamer Twitch GUI][Preview]][Releases]
+[![Streamlink Twitch GUI][Preview]][Releases]
 
 
 ## Description
 
-This is just a graphical user interface (GUI) on top of the [Livestreamer][Livestreamer] command line interface (CLI).  
+This is a graphical user interface (GUI) on top of the [Streamlink][Streamlink] command line interface (CLI).  
 
-Livestreamer Twitch GUI is a [NW.js][NW.js] application, which means that it is a web application written in JavaScript ([EmberJS][EmberJS]), HTML ([Handlebars][Handlebars]) and CSS ([LessCSS][LessCSS]) and is being run by a [Node.js][Node.js] powered version of [Chromium][Chromium].
+Streamlink Twitch GUI is a [NW.js][NW.js] application, which means that it is a web application written in JavaScript ([EmberJS][EmberJS]), HTML ([Handlebars][Handlebars]) and CSS ([LessCSS][LessCSS]) and is being run by a [Node.js][Node.js] powered version of [Chromium][Chromium].
 
 [Recent releases][Releases] / [Changelog][Changelog] / [Wiki][Wiki] / [Chat][Gitter]
 
@@ -33,7 +33,7 @@ Livestreamer Twitch GUI is a [NW.js][NW.js] application, which means that it is 
 ## Why
 
 One of the reasons people are having bad viewing experiences on [Twitch.tv][Twitch] is the usage of the flash player on their website. With the current generation of web browsers they sadly almost don't have any other choice but using flash for delivering a simple streaming service. There are some platforms and configurations where flash is causing problems though. These problems are low frame rates when watching streams or videos and also the lack of GPU acceleration leading to high CPU + memory usage which can be a big issue especially for mobile desktop devices.  
-With Livestreamer Twitch GUI you're not dependent on your browser and flash, so fewer resources are needed. Also all streams can be watched in the video player of your choice, enabling a smooth video playback.  
+With Streamlink Twitch GUI you're not dependent on your browser and flash, so fewer resources are needed. Also all streams can be watched in the video player of your choice, enabling a smooth video playback.  
 Please have in mind, that by using this application you're bypassing any ads run by Twitch (adblock users also do). If you want to support [Twitch][Twitch] or a single broadcaster, please consider buying [Twitch Turbo][TwitchTurbo] or subscribing to the broadcaster's channel. Thank you!
 
 
@@ -47,14 +47,14 @@ More informations and installation instructions can be found in the project's [W
 #### Packages
 
 Chocolatey (Windows):  
-[`choco install livestreamer-twitch-gui`][Package-Chocolatey]
+[`choco install streamlink-twitch-gui`][Package-Chocolatey]
 
 AUR (Arch Linux):  
-[`yaourt -S livestreamer-twitch-gui`][Package-AUR]  
-[`yaourt -S livestreamer-twitch-gui-git`][Package-AUR-git]
+[`yaourt -S streamlink-twitch-gui`][Package-AUR]  
+[`yaourt -S streamlink-twitch-gui-git`][Package-AUR-git]
 
 Homebrew Cask (OS X):  
-[`brew cask install livestreamer-twitch-gui`][Package-Homebrew-cask]  
+[`brew cask install streamlink-twitch-gui`][Package-Homebrew-cask]  
 
 #### Development version
 
@@ -63,9 +63,7 @@ Please don't forget to report any bugs you may encounter. Thank you very much fo
 
 #### Notes
 
-**Caution**: Livestreamer Twitch GUI depends on Livestreamer. Install [Livestreamer][Livestreamer] prior to using this application or you won't be able to launch any streams.
-
-**Windows users**: Do not install Livestreamer via pip. Instead, use the [installation package][Installation package] (requires [Microsoft Visual C++ 2008 Redistributable Package][Microsoft Visual C++ 2008 Redistributable Package]).
+Streamlink Twitch GUI depends on Streamlink. Install [Streamlink][Streamlink] prior to using this application or you won't be able to launch any streams.
 
 
 ## Build
@@ -87,13 +85,13 @@ Every contribution is welcome! Please read [CONTRIBUTING.md][Contributing] first
 
 
   [Preview]: https://cloud.githubusercontent.com/assets/467294/17694798/e23ac324-63a5-11e6-857d-54f8c9228fda.png "Preview image"
-  [Releases]: https://github.com/bastimeyer/livestreamer-twitch-gui/releases "Livestreamer Twitch GUI Releases"
-  [Issues]: https://github.com/bastimeyer/livestreamer-twitch-gui/issues "Livestreamer Twitch GUI Issues"
-  [Wiki]: https://github.com/bastimeyer/livestreamer-twitch-gui/wiki "Livestreamer Twitch GUI Wiki"
-  [Gitter]: https://gitter.im/bastimeyer/livestreamer-twitch-gui "Gitter IRC"
-  [Contributing]: https://github.com/bastimeyer/livestreamer-twitch-gui/blob/master/CONTRIBUTING.md
-  [Changelog]: https://github.com/bastimeyer/livestreamer-twitch-gui/blob/master/CHANGELOG.md
-  [Livestreamer]: https://github.com/chrippa/livestreamer "Livestreamer"
+  [Releases]: https://github.com/streamlink/streamlink-twitch-gui/releases "Streamlink Twitch GUI Releases"
+  [Issues]: https://github.com/streamlink/streamlink-twitch-gui/issues "Streamlink Twitch GUI Issues"
+  [Wiki]: https://github.com/streamlink/streamlink-twitch-gui/wiki "Streamlink Twitch GUI Wiki"
+  [Gitter]: https://gitter.im/streamlink/streamlink-twitch-gui "Gitter IRC"
+  [Contributing]: https://github.com/streamlink/streamlink-twitch-gui/blob/master/CONTRIBUTING.md
+  [Changelog]: https://github.com/streamlink/streamlink-twitch-gui/blob/master/CHANGELOG.md
+  [Streamlink]: https://github.com/streamlink/streamlink "Streamlink"
   [Twitch]: http://twitch.tv "Twitch.tv"
   [TwitchTurbo]: http://twitch.tv/products/turbo "Twitch Turbo"
   [NW.js]: https://github.com/nwjs/nw.js "NW.js"
@@ -102,14 +100,14 @@ Every contribution is welcome! Please read [CONTRIBUTING.md][Contributing] first
   [LessCSS]: http://lesscss.org/ "LessCSS"
   [Chromium]: https://www.chromium.org/ "Chromium"
   [Microsoft Visual C++ 2008 Redistributable Package]: http://www.microsoft.com/en-us/download/details.aspx?id=29 "Microsoft Visual C++ 2008 Redistributable Package"
-  [Installation package]: http://docs.livestreamer.io/install.html#windows-binaries "Livestreamer installation package"
+  [Installation package]: https://streamlink.github.io/install.html#windows-binaries "Streamlink installation package"
   [Node.js]: https://nodejs.org "Node.js"
   [npm]: https://npmjs.org "Node Packaged Modules"
   [badge-platforms]: https://img.shields.io/badge/platform-win%20%7C%20osx%20%7C%20linux-green.svg?style=flat-square "Supported platforms"
-  [badge-release]: https://img.shields.io/github/release/bastimeyer/livestreamer-twitch-gui.svg?style=flat-square "Latest release"
-  [badge-issues]: https://img.shields.io/github/issues/bastimeyer/livestreamer-twitch-gui.svg?style=flat-square "Open issues"
-  [badge-gitter]: https://img.shields.io/gitter/room/bastimeyer/livestreamer-twitch-gui.svg?style=flat-square "Gitter IRC"
-  [Package-Chocolatey]: https://chocolatey.org/packages/livestreamer-twitch-gui "Chocolatey package"
-  [Package-AUR]: https://aur.archlinux.org/packages/livestreamer-twitch-gui "AUR stable package"
-  [Package-AUR-git]: https://aur.archlinux.org/packages/livestreamer-twitch-gui-git "AUR git package"
+  [badge-release]: https://img.shields.io/github/release/streamlink/streamlink-twitch-gui.svg?style=flat-square "Latest release"
+  [badge-issues]: https://img.shields.io/github/issues/streamlink/streamlink-twitch-gui.svg?style=flat-square "Open issues"
+  [badge-gitter]: https://img.shields.io/gitter/room/streamlink/streamlink-twitch-gui.svg?style=flat-square "Gitter IRC"
+  [Package-Chocolatey]: https://chocolatey.org/packages/streamlink-twitch-gui "Chocolatey package"
+  [Package-AUR]: https://aur.archlinux.org/packages/streamlink-twitch-gui "AUR stable package"
+  [Package-AUR-git]: https://aur.archlinux.org/packages/streamlink-twitch-gui-git "AUR git package"
   [Package-Homebrew-cask]: https://caskroom.github.io/

--- a/build/resources/linux/add-menuitem.sh
+++ b/build/resources/linux/add-menuitem.sh
@@ -4,27 +4,27 @@ DIR=$(readlink -f "${0}")
 HERE=$(dirname "${DIR}")
 
 TMP=$(mktemp --directory)
-DESKTOP="${TMP}/livestreamer-twitch-gui.desktop"
+DESKTOP="${TMP}/streamlink-twitch-gui.desktop"
 
 cat << EOF > "${DESKTOP}"
 [Desktop Entry]
 Type=Application
-Name=Livestreamer Twitch GUI
-GenericName=Twitch.tv browser for livestreamer
+Name=Streamlink Twitch GUI
+GenericName=Twitch.tv browser for streamlink
 Comment=Browse Twitch.tv and watch streams in your videoplayer of choice
-Keywords=livestreamer;twitch;
+Keywords=streamlink;livestreamer;twitch;
 Categories=AudioVideo;
 Exec=${HERE}/start.sh
-Icon=livestreamer-twitch-gui
+Icon=streamlink-twitch-gui
 EOF
 
 xdg-desktop-menu install "${DESKTOP}"
-xdg-icon-resource install --size 16 "${HERE}/icons/icon-16.png" livestreamer-twitch-gui
-xdg-icon-resource install --size 32 "${HERE}/icons/icon-32.png" livestreamer-twitch-gui
-xdg-icon-resource install --size 48 "${HERE}/icons/icon-48.png" livestreamer-twitch-gui
-xdg-icon-resource install --size 64 "${HERE}/icons/icon-64.png" livestreamer-twitch-gui
-xdg-icon-resource install --size 128 "${HERE}/icons/icon-128.png" livestreamer-twitch-gui
-xdg-icon-resource install --size 256 "${HERE}/icons/icon-256.png" livestreamer-twitch-gui
+xdg-icon-resource install --size 16 "${HERE}/icons/icon-16.png" streamlink-twitch-gui
+xdg-icon-resource install --size 32 "${HERE}/icons/icon-32.png" streamlink-twitch-gui
+xdg-icon-resource install --size 48 "${HERE}/icons/icon-48.png" streamlink-twitch-gui
+xdg-icon-resource install --size 64 "${HERE}/icons/icon-64.png" streamlink-twitch-gui
+xdg-icon-resource install --size 128 "${HERE}/icons/icon-128.png" streamlink-twitch-gui
+xdg-icon-resource install --size 256 "${HERE}/icons/icon-256.png" streamlink-twitch-gui
 
 rm "${DESKTOP}"
 rm -R "${TMP}"

--- a/build/resources/linux/remove-menuitem.sh
+++ b/build/resources/linux/remove-menuitem.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-xdg-desktop-menu uninstall livestreamer-twitch-gui.desktop
-xdg-icon-resource uninstall --size  16 livestreamer-twitch-gui
-xdg-icon-resource uninstall --size  32 livestreamer-twitch-gui
-xdg-icon-resource uninstall --size  48 livestreamer-twitch-gui
-xdg-icon-resource uninstall --size  64 livestreamer-twitch-gui
-xdg-icon-resource uninstall --size 128 livestreamer-twitch-gui
-xdg-icon-resource uninstall --size 256 livestreamer-twitch-gui
+xdg-desktop-menu uninstall streamlink-twitch-gui.desktop
+xdg-icon-resource uninstall --size  16 streamlink-twitch-gui
+xdg-icon-resource uninstall --size  32 streamlink-twitch-gui
+xdg-icon-resource uninstall --size  48 streamlink-twitch-gui
+xdg-icon-resource uninstall --size  64 streamlink-twitch-gui
+xdg-icon-resource uninstall --size 128 streamlink-twitch-gui
+xdg-icon-resource uninstall --size 256 streamlink-twitch-gui

--- a/build/resources/linux/start.sh
+++ b/build/resources/linux/start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # ---------------------------------------------------
-# Livestreamer Twitch GUI - application launch script
+# Streamlink Twitch GUI - application launch script
 # ---------------------------------------------------
 
 
@@ -12,7 +12,7 @@ CHECKNEWVERSIONS=true
 # ==================================================================================================
 
 
-EXEC="livestreamer-twitch-gui"
+EXEC="streamlink-twitch-gui"
 DIR=$(readlink -f "${0}")
 HERE=$(dirname "${DIR}")
 

--- a/build/resources/package/chocolatey/livestreamer-twitch-gui.nuspec.tpl
+++ b/build/resources/package/chocolatey/livestreamer-twitch-gui.nuspec.tpl
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <id>livestreamer-twitch-gui</id>
+    <id>streamlink-twitch-gui</id>
     <title><%= name %></title>
     <version><%= version %></version>
     <authors><%= author %></authors>
     <owners>Sebastian Meyer, Scott Walters</owners>
-    <summary>A multi platform Twitch.tv browser for Livestreamer</summary>
-    <description>This is just a graphical user interface (GUI) on top of the [Livestreamer][Livestreamer] command line interface (CLI).
+    <summary>A multi platform Twitch.tv browser for Streamlink</summary>
+    <description>This is a graphical user interface (GUI) on top of the [Streamlink][Streamlink] command line interface (CLI).
 
-Livestreamer Twitch GUI is a [NW.js][NW.js] application, which means that it is a web application written in JavaScript ([EmberJS][EmberJS]), HTML ([Handlebars][Handlebars]) and CSS ([LessCSS][LessCSS]) and is being run by a [Node.js][Node.js] powered version of [Chromium][Chromium].
+Streamlink Twitch GUI is a [NW.js][NW.js] application, which means that it is a web application written in JavaScript ([EmberJS][EmberJS]), HTML ([Handlebars][Handlebars]) and CSS ([LessCSS][LessCSS]) and is being run by a [Node.js][Node.js] powered version of [Chromium][Chromium].
 
 #### Package parameters
 
 * `/Purge` - (uninstall) delete appdata and cache folders upon install
 
-Example: `choco uninstall livestreamer-twitch-gui -y -params '"/Purge"'`
+Example: `choco uninstall streamlink-twitch-gui -y -params '"/Purge"'`
 
-  [Livestreamer]: https://github.com/chrippa/livestreamer "Livestreamer"
+  [Streamlink]: https://github.com/streamlink/streamlink "Streamlink"
   [NW.js]: https://github.com/nwjs/nw.js "NW.js"
   [EmberJS]: http://emberjs.com/ "EmberJS"
   [Handlebars]: http://handlebarsjs.com/ "Handlebars.js"
@@ -26,14 +26,14 @@ Example: `choco uninstall livestreamer-twitch-gui -y -params '"/Purge"'`
   [Chromium]: https://www.chromium.org/ "Chromium"
     </description>
     <projectUrl><%= homepage %></projectUrl>
-    <packageSourceUrl>https://github.com/bastimeyer/livestreamer-twitch-gui</packageSourceUrl>
-    <tags>livestreamer twitch gui streaming</tags>
+    <packageSourceUrl>https://github.com/streamlink/streamlink-twitch-gui</packageSourceUrl>
+    <tags>streamlink twitch gui livestreamer streaming</tags>
     <copyright>Sebastian Meyer</copyright>
-    <licenseUrl>https://github.com/bastimeyer/livestreamer-twitch-gui/blob/master/LICENSE</licenseUrl>
-    <docsUrl>https://github.com/bastimeyer/livestreamer-twitch-gui/wiki</docsUrl>
-    <bugTrackerUrl>https://github.com/bastimeyer/livestreamer-twitch-gui/issues</bugTrackerUrl>
+    <licenseUrl>https://github.com/streamlink/streamlink-twitch-gui/blob/master/LICENSE</licenseUrl>
+    <docsUrl>https://github.com/streamlink/streamlink-twitch-gui/wiki</docsUrl>
+    <bugTrackerUrl>https://github.com/streamlink/streamlink-twitch-gui/issues</bugTrackerUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <iconUrl>https://cdn.rawgit.com/bastimeyer/livestreamer-twitch-gui/master/src/img/icon-256.png</iconUrl>
+    <iconUrl>https://cdn.rawgit.com/streamlink/streamlink-twitch-gui/master/src/img/icon-256.png</iconUrl>
     <dependencies>
       <dependency id="livestreamer" version="1.12.2"/>
     </dependencies>

--- a/build/resources/package/chocolatey/tools/chocolateyinstall.ps1.tpl
+++ b/build/resources/package/chocolatey/tools/chocolateyinstall.ps1.tpl
@@ -1,14 +1,14 @@
-$packageName = 'livestreamer-twitch-gui'
+$packageName = 'streamlink-twitch-gui'
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $installDir = "$(Split-Path -parent $toolsDir)"
 $extractDir = "$(Split-Path -parent $installDir)"
 
 Install-ChocolateyZipPackage `
 	-PackageName    $packageName `
-	-Url            "https://github.com/bastimeyer/livestreamer-twitch-gui/releases/download/v<%- version %>/livestreamer-twitch-gui-v<%- version %>-win32.zip" `
+	-Url            "https://github.com/streamlink/streamlink-twitch-gui/releases/download/v<%- version %>/streamlink-twitch-gui-v<%- version %>-win32.zip" `
 	-Checksum       "<%= checksum %>" `
 	-ChecksumType   "sha256" `
-	-Url64bit       "https://github.com/bastimeyer/livestreamer-twitch-gui/releases/download/v<%- version %>/livestreamer-twitch-gui-v<%- version %>-win64.zip" `
+	-Url64bit       "https://github.com/streamlink/streamlink-twitch-gui/releases/download/v<%- version %>/streamlink-twitch-gui-v<%- version %>-win64.zip" `
 	-Checksum64     "<%= checksum64 %>" `
 	-ChecksumType64 "sha256" `
 	-UnzipLocation  "$extractDir"

--- a/build/resources/package/chocolatey/tools/chocolateyuninstall.ps1.tpl
+++ b/build/resources/package/chocolatey/tools/chocolateyuninstall.ps1.tpl
@@ -1,4 +1,4 @@
-$packageName = 'livestreamer-twitch-gui'
+$packageName = 'streamlink-twitch-gui'
 $packageParameters = $env:chocolateyPackageParameters
 
 $desktop = [Environment]::GetFolderPath("Desktop")

--- a/build/tasks/configs/package.js
+++ b/build/tasks/configs/package.js
@@ -5,8 +5,8 @@ module.exports = {
 	options: {
 		changelogFile: PATH.resolve( "CHANGELOG.md" ),
 		// has a rate limit of 60 requests per IP per hour
-		githubReleases: "https://api.github.com/repos/bastimeyer/livestreamer-twitch-gui/releases",
-		githubReleasesAtom: "https://github.com/bastimeyer/livestreamer-twitch-gui/releases.atom"
+		githubReleases: "https://api.github.com/repos/streamlink/streamlink-twitch-gui/releases",
+		githubReleasesAtom: "https://github.com/streamlink/streamlink-twitch-gui/releases.atom"
 	},
 
 	chocolatey: {

--- a/build/tasks/configs/template.js
+++ b/build/tasks/configs/template.js
@@ -12,8 +12,8 @@ module.exports = {
 			}
 		},
 		"files": {
-			"<%= dir.package %>/chocolatey/livestreamer-twitch-gui.nuspec":
-				"<%= dir.resources %>/package/chocolatey/livestreamer-twitch-gui.nuspec.tpl",
+			"<%= dir.package %>/chocolatey/streamlink-twitch-gui.nuspec":
+				"<%= dir.resources %>/package/chocolatey/streamlink-twitch-gui.nuspec.tpl",
 			"<%= dir.package %>/chocolatey/tools/chocolateyinstall.ps1":
 				"<%= dir.resources %>/package/chocolatey/tools/chocolateyinstall.ps1.tpl",
 			"<%= dir.package %>/chocolatey/tools/chocolateyuninstall.ps1":

--- a/build/travis/templates/releases.md
+++ b/build/travis/templates/releases.md
@@ -3,7 +3,7 @@
 
 ### Release highlights (v<%= version %>)
 
-<%= changelog %> / [Wiki](https://github.com/bastimeyer/livestreamer-twitch-gui/wiki) / [Installation instructions](https://github.com/bastimeyer/livestreamer-twitch-gui/wiki/Installation) / [Open issues](https://github.com/bastimeyer/livestreamer-twitch-gui/issues) / [Chat](https://gitter.com/bastimeyer/livestreamer-twitch-gui)
+<%= changelog %> / [Wiki](https://github.com/streamlink/streamlink-twitch-gui/wiki) / [Installation instructions](https://github.com/streamlink/streamlink-twitch-gui/wiki/Installation) / [Open issues](https://github.com/streamlink/streamlink-twitch-gui/issues) / [Chat](https://gitter.com/streamlink/streamlink-twitch-gui)
 
 <% if ( donation && donation.length ) { %>
 ### Donate

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
 	"license": "MIT",
 
 	"author": "Sebastian Meyer",
-	"homepage": "https://github.com/bastimeyer/streamlink-twitch-gui",
+	"homepage": "https://github.com/streamlink/streamlink-twitch-gui",
 
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/bastimeyer/streamlink-twitch-gui.git"
+		"url": "https://github.com/streamlink/streamlink-twitch-gui.git"
 	},
 
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
 	"license": "MIT",
 
 	"author": "Sebastian Meyer",
-	"homepage": "https://github.com/bastimeyer/livestreamer-twitch-gui",
+	"homepage": "https://github.com/bastimeyer/streamlink-twitch-gui",
 
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/bastimeyer/livestreamer-twitch-gui.git"
+		"url": "https://github.com/bastimeyer/streamlink-twitch-gui.git"
 	},
 
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "livestreamer-twitch-gui",
+	"name": "streamlink-twitch-gui",
 	"version": "0.16.0",
 	"license": "MIT",
 

--- a/src/config/dirs.json
+++ b/src/config/dirs.json
@@ -1,3 +1,3 @@
 {
-	"temp": "livestreamer-twitch-gui"
+	"temp": "streamlink-twitch-gui"
 }

--- a/src/config/main.json
+++ b/src/config/main.json
@@ -1,6 +1,6 @@
 {
-	"display-name": "Livestreamer Twitch GUI",
-	"app-identifier": "livestreamer-twitch-gui",
+	"display-name": "Streamlink Twitch GUI",
+	"app-identifier": "streamlink-twitch-gui",
 	"nwjs-version": "0.18.8",
 	"urls": {
 		"homepage": "https://github.com/bastimeyer/livestreamer-twitch-gui",

--- a/src/config/main.json
+++ b/src/config/main.json
@@ -3,12 +3,12 @@
 	"app-identifier": "streamlink-twitch-gui",
 	"nwjs-version": "0.18.8",
 	"urls": {
-		"homepage": "https://github.com/bastimeyer/livestreamer-twitch-gui",
-		"release": "https://github.com/bastimeyer/livestreamer-twitch-gui/releases/tag/v{version}",
-		"changelog": "https://github.com/bastimeyer/livestreamer-twitch-gui/blob/master/CHANGELOG.md",
-		"wiki": "https://github.com/bastimeyer/livestreamer-twitch-gui/wiki",
-		"bugs": "https://github.com/bastimeyer/livestreamer-twitch-gui/issues",
-		"chat": "https://gitter.im/bastimeyer/livestreamer-twitch-gui",
-		"contributors": "https://github.com/bastimeyer/livestreamer-twitch-gui/graphs/contributors"
+		"homepage": "https://github.com/streamlink/streamlink-twitch-gui",
+		"release": "https://github.com/streamlink/streamlink-twitch-gui/releases/tag/v{version}",
+		"changelog": "https://github.com/streamlink/streamlink-twitch-gui/blob/master/CHANGELOG.md",
+		"wiki": "https://github.com/streamlink/streamlink-twitch-gui/wiki",
+		"bugs": "https://github.com/streamlink/streamlink-twitch-gui/issues",
+		"chat": "https://gitter.im/streamlink/streamlink-twitch-gui",
+		"contributors": "https://github.com/streamlink/streamlink-twitch-gui/graphs/contributors"
 	}
 }

--- a/src/config/update.json
+++ b/src/config/update.json
@@ -2,6 +2,6 @@
 	"check-again": 604800000,
 	"githubreleases": {
 		"host": "https://api.github.com",
-		"namespace": "repos/bastimeyer/livestreamer-twitch-gui"
+		"namespace": "repos/streamlink/streamlink-twitch-gui"
 	}
 }

--- a/src/index.html
+++ b/src/index.html
@@ -2,6 +2,6 @@
 <html>
 <head>
 <meta charset="utf8">
-<title>Livestreamer Twitch GUI</title>
+<title>Streamlink Twitch GUI</title>
 </head>
 </html>

--- a/src/package.json
+++ b/src/package.json
@@ -1,11 +1,11 @@
 {
-	"name": "livestreamer-twitch-gui",
+	"name": "streamlink-twitch-gui",
 	"version": "0.16.0",
 
 	"main": "index.html",
 
 	"window": {
-		"title": "Livestreamer Twitch GUI",
+		"title": "Streamlink Twitch GUI",
 		"frame": false,
 		"resizable": true,
 		"show": false,

--- a/src/styles/app.less
+++ b/src/styles/app.less
@@ -1,5 +1,5 @@
 /*!
- * Livestreamer-Twitch-GUI
+ * Streamlink-Twitch-GUI
  * @author Sebastian Meyer
  * @licence MIT
  */

--- a/src/test/package.json
+++ b/src/test/package.json
@@ -1,11 +1,11 @@
 {
-	"name": "livestreamer-twitch-gui-test",
+	"name": "streamlink-twitch-gui-test",
 	"version": "0.0.1",
 
 	"main": "index.html",
 
 	"window": {
-		"title": "Livestreamer Twitch GUI Test",
+		"title": "Streamlink Twitch GUI Test",
 		"frame": true,
 		"resizable": true,
 		"show": false,


### PR DESCRIPTION
PR for the upcoming repo-rename changes.
I would like to do all this during this weekend if possible.
This will enable the `1.0.0` release.

@cdrage
I'll send you an email (the address on your GH profile) regarding the repo transition, but I also wanted to ping you here, so you can see the status of this PR.

-----

**To the package maintainers:**
I'm pinging you here, because I want to make sure that the transition will be as smooth as possible.
Also, let's ignore the automation part I was talking about in the last release for now... 😃 

@InfernoZeus 
https://github.com/bastimeyer/livestreamer-twitch-gui/commit/94a4a844f52f0877faf02f540ec211e861c1a7af#commitcomment-19451912
The package changes can all easily be done after the `1.0.0` release.
Could you add me to the co-maintainer list then, so I can apply changes to it as well? Btw, the `xorg-xwininfo` package is not required anymore. Can we also please change the format of the package version to not include the "v"? I'm just using it for the git tags and file names and it shouldn't be included in package version.
The streamlink AUR package is being maintained by @mmetak, but he already asked a packager of the community repo to include it in there (see https://github.com/streamlink/streamlink/pull/188#issuecomment-262067461).

@scowalt 
https://github.com/bastimeyer/livestreamer-twitch-gui/commit/94a4a844f52f0877faf02f540ec211e861c1a7af#commitcomment-19439801
This PR also includes changes to the choco package config files, although probably unnecessary, since you've said that you wanted to change the package to not be downloader-package anymore. But wouldn't this require a setup for automatically built packages? I think it's probably wiser to keep everything the way it is for now, so the release doesn't get delayed any further.
Btw, I'm not sure if I have messed up the changelog parser by using a different format in the latest changelog. You should validate this before publishing it.

@NGMarmaduke
This will probably just be a simple package name and file URL change.
Btw, I will change the filename again before I'm going to release `1.0.0` ([`macOS` instead of `osx64`](https://github.com/bastimeyer/livestreamer-twitch-gui/blob/88461c43841eb84ac064bda7243cc7538b2264ca/build/tasks/configs/compress.js#L29)).

@scowalt 
@NGMarmaduke 
Do you guys also want to create a package for Streamlink, so we don't need to depend on Livestreamer any more? There are no streamlink packages available yet in the repos of these package managers.
I hope I don't sound in any way demanding or so. 😄  If you want to do this, please open a thread on the streamlink repo and let them know.

https://chocolatey.org/packages/livestreamer
https://github.com/Homebrew/homebrew-core/blob/master/Formula/livestreamer.rb

-----

Thanks a lot!
I hope I don't have missed anything important.